### PR TITLE
put assessmentId out of createQuizInput

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/controller/QuizController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/controller/QuizController.java
@@ -28,8 +28,8 @@ public class QuizController {
     }
 
     @MutationMapping
-    public Quiz createQuiz(@Argument CreateQuizInput input) {
-        return quizService.createQuiz(input);
+    public Quiz createQuiz(@Argument UUID assessmentId, @Argument CreateQuizInput input) {
+        return quizService.createQuiz(assessmentId, input);
     }
 
     @MutationMapping

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/service/QuizService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/service/QuizService.java
@@ -55,10 +55,11 @@ public class QuizService {
      * @return the created quiz
      * @throws ValidationException if the question numbers are not unique or any question does not validate
      */
-    public Quiz createQuiz(CreateQuizInput input) {
+    public Quiz createQuiz(UUID assessmentId, CreateQuizInput input) {
         quizValidator.validateCreateQuizInput(input);
 
         QuizEntity entity = quizMapper.createQuizInputToEntity(input);
+        entity.setAssessmentId(assessmentId);
 
         QuizEntity savedEntity = quizRepository.save(entity);
         return entityToDto(savedEntity);

--- a/src/main/resources/graphql/service/mutation.graphqls
+++ b/src/main/resources/graphql/service/mutation.graphqls
@@ -2,7 +2,7 @@ type Mutation {
     """
     Create a quiz.
     """
-    createQuiz(input: CreateQuizInput!): Quiz!
+    createQuiz(assessmentId: UUID!, input: CreateQuizInput!): Quiz!
 
     """
     Modify a quiz.
@@ -60,10 +60,6 @@ type QuizMutation {
 
 
 input CreateQuizInput {
-    """
-    Identifier of the quiz, same as the identifier of the assessment.
-    """
-    assessmentId: UUID!
 
     """
     Threshold of the quiz, i.e., how many questions the user has to answer correctly to pass the quiz.

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/CreateQuizMutationTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/CreateQuizMutationTest.java
@@ -34,8 +34,8 @@ class CreateQuizMutationTest {
     @Transactional
     @Commit
     void testCreateQuizWithQuestions(GraphQlTester graphQlTester) {
+        UUID assessmentId = UUID.randomUUID();
         CreateQuizInput createQuizInput = CreateQuizInput.builder()
-                .setAssessmentId(UUID.randomUUID())
                 .setRequiredCorrectAnswers(1)
                 .setQuestionPoolingMode(QuestionPoolingMode.RANDOM)
                 .setNumberOfRandomlySelectedQuestions(2)
@@ -72,8 +72,8 @@ class CreateQuizMutationTest {
                 .build();
 
         String query = """
-                mutation createQuiz($input: CreateQuizInput!) {
-                    createQuiz(input: $input) {
+                mutation createQuiz($id: UUID!, $input: CreateQuizInput!) {
+                    createQuiz(assessmentId: $id, input: $input) {
                         assessmentId
                         requiredCorrectAnswers
                         questionPoolingMode
@@ -98,10 +98,11 @@ class CreateQuizMutationTest {
         // so check the fields manually
         List<MultipleChoiceQuestion> questions = graphQlTester.document(query)
                 .variable("input", createQuizInput)
+                .variable("id", assessmentId)
                 .execute()
 
                 .path("createQuiz.assessmentId").entity(UUID.class)
-                .isEqualTo(createQuizInput.getAssessmentId())
+                .isEqualTo(assessmentId)
 
                 .path("createQuiz.requiredCorrectAnswers").entity(Integer.class)
                 .isEqualTo(1)
@@ -134,8 +135,8 @@ class CreateQuizMutationTest {
      */
     @Test
     void testCreateQuizWithDuplicateNumbersInQuestion(GraphQlTester graphQlTester) {
+        UUID assessmentId = UUID.randomUUID();
         CreateQuizInput createQuizInput = CreateQuizInput.builder()
-                .setAssessmentId(UUID.randomUUID())
                 .setRequiredCorrectAnswers(1)
                 .setQuestionPoolingMode(QuestionPoolingMode.RANDOM)
                 .setNumberOfRandomlySelectedQuestions(2)
@@ -172,14 +173,15 @@ class CreateQuizMutationTest {
                 .build();
 
         String query = """
-                mutation createQuiz($input: CreateQuizInput!) {
-                    createQuiz(input: $input) {
+                mutation createQuiz($id: UUID!, $input: CreateQuizInput!) {
+                    createQuiz(assessmentId: $id, input: $input) {
                         assessmentId
                     }
                 }""";
 
         graphQlTester.document(query)
                 .variable("input", createQuizInput)
+                .variable("id", assessmentId)
                 .execute()
                 .errors()
                 .satisfy(errors -> {

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/QuizEntityToCreateInputMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/QuizEntityToCreateInputMatcher.java
@@ -26,10 +26,6 @@ public class QuizEntityToCreateInputMatcher extends TypeSafeDiagnosingMatcher<Qu
 
     @Override
     protected boolean matchesSafely(QuizEntity item, Description mismatchDescription) {
-        if (!item.getAssessmentId().equals(expected.getAssessmentId())) {
-            mismatchDescription.appendText("assessmentId was ").appendValue(item.getAssessmentId());
-            return false;
-        }
         if (item.getRequiredCorrectAnswers() != expected.getRequiredCorrectAnswers()) {
             mismatchDescription.appendText("requiredCorrectAnswers was ").appendValue(item.getRequiredCorrectAnswers());
             return false;


### PR DESCRIPTION
## Description of changes
Moved assessmentId out of the createQuizInput because that makes it possible to have a combined query to create quiz content in the gateway

  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [x] automated integration test
- [ ] automated acceptance test
- [ ] manual, exploratory test
    
## Checklist before requesting a review
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code fulfills all acceptance criteria
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
