### PR TITLE
fix createQuiz not working without questions

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/mapper/QuizMapper.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/mapper/QuizMapper.java
@@ -6,10 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Stream;
 
-import static java.util.Comparator.*;
+import static java.util.Comparator.comparing;
 
 @Component
 @RequiredArgsConstructor
@@ -74,13 +74,17 @@ public class QuizMapper {
     }
 
     private void assignNumbersIfNull(List<CreateMultipleChoiceQuestionInput> createMultipleChoiceQuestionInputs) {
-        createMultipleChoiceQuestionInputs.sort(
-                comparing(CreateMultipleChoiceQuestionInput::getNumber, nullsFirst(naturalOrder())));
-        int highestNumber = createMultipleChoiceQuestionInputs.get(createMultipleChoiceQuestionInputs.size() - 1).getNumber();
+        OptionalInt maxNumber = createMultipleChoiceQuestionInputs.stream()
+                .map(CreateMultipleChoiceQuestionInput::getNumber)
+                .filter(Objects::nonNull)
+                .mapToInt(Integer::intValue)
+                .max();
 
-        for (int i = 0; i < createMultipleChoiceQuestionInputs.size(); i++) {
-            if (createMultipleChoiceQuestionInputs.get(i).getNumber() == null) {
-                createMultipleChoiceQuestionInputs.get(i).setNumber(highestNumber + i + 1);
+        for (CreateMultipleChoiceQuestionInput createMultipleChoiceQuestionInput : createMultipleChoiceQuestionInputs) {
+            if (createMultipleChoiceQuestionInput.getNumber() == null) {
+                int newNumber = maxNumber.orElse(0) + 1;
+                createMultipleChoiceQuestionInput.setNumber(newNumber);
+                maxNumber = OptionalInt.of(newNumber);
             }
         }
 


### PR DESCRIPTION
## Description of changes
An exception was thrown when trying to create a quiz without questions. This fixes it.

  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [x] automated integration test
- [ ] automated acceptance test
- [ ] manual, exploratory test

    
## Checklist before requesting a review
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
