### PR TITLE
add clozes (and start on other quiz types)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'de.unistuttgart.iste.gits:gits-common:0.3.0'
+	implementation 'de.unistuttgart.iste.gits:gits-common:0.3.1'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-graphql'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'de.unistuttgart.iste.gits:gits-common:0.1.1'
+	implementation 'de.unistuttgart.iste.gits:gits-common:0.3.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-graphql'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/QuizServiceApplication.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/QuizServiceApplication.java
@@ -2,11 +2,13 @@ package de.unistuttgart.iste.gits.quiz_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 /**
  * This is the entry point of the application.
  */
 @SpringBootApplication
+@EntityScan({"de.unistuttgart.iste.gits.common.resource_markdown", "de.unistuttgart.iste.gits.quiz_service.persistence.dao"})
 public class QuizServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/controller/QuizController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/controller/QuizController.java
@@ -55,6 +55,16 @@ public class QuizController {
     }
 
     @SchemaMapping(typeName = "QuizMutation")
+    public Quiz addClozeQuestion(@Argument CreateClozeQuestionInput input, QuizMutation quizMutation) {
+        return quizService.addClozeQuestion(quizMutation.getAssessmentId(), input);
+    }
+
+    @SchemaMapping(typeName = "QuizMutation")
+    public Quiz updateClozeQuestion(@Argument UpdateClozeQuestionInput input, QuizMutation quizMutation) {
+        return quizService.updateClozeQuestion(quizMutation.getAssessmentId(), input);
+    }
+
+    @SchemaMapping(typeName = "QuizMutation")
     public Quiz removeQuestion(@Argument int number, QuizMutation quizMutation) {
         return quizService.removeQuestion(quizMutation.getAssessmentId(), number);
     }

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/AssociationEmbeddable.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/AssociationEmbeddable.java
@@ -1,0 +1,24 @@
+package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
+
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Embeddable
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AssociationEmbeddable {
+
+    @Column(nullable = false, length = 255, name = "left_side")
+    private String left;
+
+    @Column(nullable = false, length = 255, name = "right_side")
+    private String right;
+
+    @Embedded
+    @Builder.Default
+    private ResourceMarkdownEmbeddable feedback = new ResourceMarkdownEmbeddable("");
+
+}

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/AssociationQuestionEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/AssociationQuestionEntity.java
@@ -1,0 +1,29 @@
+package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
+
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity(name = "AssociationQuestion")
+@ToString(callSuper = true)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AssociationQuestionEntity extends QuestionEntity {
+
+    @Embedded
+    @Builder.Default
+    private ResourceMarkdownEmbeddable text = new ResourceMarkdownEmbeddable("");
+
+    @ElementCollection
+    @Builder.Default
+    private List<AssociationEmbeddable> correctAssociations = new ArrayList<>();
+
+}

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/ClozeElementEmbeddable.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/ClozeElementEmbeddable.java
@@ -1,0 +1,28 @@
+package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
+
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
+import de.unistuttgart.iste.gits.generated.dto.ClozeElementType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Embeddable
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClozeElementEmbeddable {
+
+    @Enumerated(EnumType.ORDINAL)
+    private ClozeElementType type;
+
+    @Embedded
+    @Builder.Default
+    private ResourceMarkdownEmbeddable text = new ResourceMarkdownEmbeddable("");
+
+    @Column(nullable = true)
+    private String correctAnswer;
+
+    @OneToOne(optional = true, cascade = CascadeType.ALL)
+    private ResourceMarkdownEntity feedback;
+}

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/ClozeQuestionEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/ClozeQuestionEntity.java
@@ -1,0 +1,31 @@
+package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity(name = "ClozeQuestion")
+@ToString(callSuper = true)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClozeQuestionEntity extends QuestionEntity {
+
+    @ElementCollection
+    @Builder.Default
+    private List<ClozeElementEmbeddable> clozeElements = new ArrayList<>();
+
+    @ElementCollection
+    @Builder.Default
+    private List<String> additionalWrongAnswers = new ArrayList<>();
+
+    @Column(nullable = false)
+    private boolean showBlanksList;
+}

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/ExactAnswerQuestionEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/ExactAnswerQuestionEntity.java
@@ -1,0 +1,33 @@
+package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
+
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Entity(name = "ExactAnswerQuestion")
+@ToString(callSuper = true)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ExactAnswerQuestionEntity extends QuestionEntity {
+
+    @Embedded
+    @Builder.Default
+    private ResourceMarkdownEmbeddable text = new ResourceMarkdownEmbeddable("");
+
+    @ElementCollection
+    private List<String> correctAnswers;
+
+    @Column(nullable = false)
+    private boolean caseSensitive;
+
+    @OneToOne(optional = true, cascade = CascadeType.ALL)
+    private ResourceMarkdownEntity feedback;
+}

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/MultipleChoiceAnswerEmbeddable.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/MultipleChoiceAnswerEmbeddable.java
@@ -1,7 +1,7 @@
 package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Embeddable
@@ -11,14 +11,13 @@ import lombok.*;
 @AllArgsConstructor
 public class MultipleChoiceAnswerEmbeddable {
 
-    @Column(length = 1000, nullable = false)
-    @Builder.Default
-    private String text = "";
+    @OneToOne(optional = false, cascade = CascadeType.ALL)
+    private ResourceMarkdownEntity answerText;
 
     @Column(nullable = false)
     @Builder.Default
     private boolean correct = false;
 
-    @Column(length = 1000, nullable = true)
-    private String feedback;
+    @OneToOne(optional = true, cascade = CascadeType.ALL)
+    private ResourceMarkdownEntity feedback;
 }

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/MultipleChoiceQuestionEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/MultipleChoiceQuestionEntity.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
 
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
 import de.unistuttgart.iste.gits.generated.dto.QuestionType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -19,9 +20,9 @@ public class MultipleChoiceQuestionEntity extends QuestionEntity {
         this.setType(QuestionType.MULTIPLE_CHOICE);
     }
 
-    @Column(length = 1000, nullable = false)
+    @Embedded
     @Builder.Default
-    private String text = "";
+    private ResourceMarkdownEmbeddable text = new ResourceMarkdownEmbeddable("");
 
     @ElementCollection
     @Builder.Default

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/NumericQuestionEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/NumericQuestionEntity.java
@@ -1,0 +1,31 @@
+package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
+
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity(name = "NumericQuestion")
+@ToString(callSuper = true)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NumericQuestionEntity extends QuestionEntity {
+
+    @Embedded
+    @Builder.Default
+    private ResourceMarkdownEmbeddable text = new ResourceMarkdownEmbeddable("");
+
+    @Column(nullable = false)
+    private double correctAnswer;
+
+    @Column(nullable = false)
+    private double tolerance;
+
+    @OneToOne(optional = true, cascade = CascadeType.ALL)
+    private ResourceMarkdownEntity feedback;
+}

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/QuestionEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/QuestionEntity.java
@@ -1,14 +1,12 @@
 package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
 
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
 import de.unistuttgart.iste.gits.generated.dto.QuestionType;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 @Entity(name = "Question")
 @Data
@@ -29,8 +27,8 @@ public class QuestionEntity {
     @Enumerated(EnumType.ORDINAL)
     private QuestionType type;
 
-    @Column(length = 1000, nullable = true)
-    private String hint;
+    @OneToOne(optional = true, cascade = CascadeType.ALL)
+    private ResourceMarkdownEntity hint;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "question_id")

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/QuizEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/QuizEntity.java
@@ -4,8 +4,7 @@ import de.unistuttgart.iste.gits.generated.dto.QuestionPoolingMode;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Entity(name = "Quiz")
 @Data
@@ -19,7 +18,8 @@ public class QuizEntity {
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("number ASC")
-    private List<QuestionEntity> questionPool;
+    @Builder.Default
+    private List<QuestionEntity> questionPool = new ArrayList<>();
 
     @Column(nullable = false)
     private int requiredCorrectAnswers;

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/SelfAssessmentQuestionEntity.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/dao/SelfAssessmentQuestionEntity.java
@@ -1,0 +1,26 @@
+package de.unistuttgart.iste.gits.quiz_service.persistence.dao;
+
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity(name = "SelfAssessmentQuestion")
+@ToString(callSuper = true)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelfAssessmentQuestionEntity extends QuestionEntity {
+
+    @Embedded
+    @Builder.Default
+    private ResourceMarkdownEmbeddable text = new ResourceMarkdownEmbeddable("");
+
+    @OneToOne(optional = true, cascade = CascadeType.ALL)
+    @Builder.Default
+    private ResourceMarkdownEntity solutionSuggestion = new ResourceMarkdownEntity("");
+}

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/mapper/QuizMapper.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/persistence/mapper/QuizMapper.java
@@ -6,11 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
-import java.util.stream.Stream;
-
-import static java.util.Comparator.comparing;
-
 @Component
 @RequiredArgsConstructor
 public class QuizMapper {
@@ -42,23 +37,7 @@ public class QuizMapper {
     }
 
     public QuizEntity createQuizInputToEntity(CreateQuizInput createQuizInput) {
-        List<CreateMultipleChoiceQuestionInput> multipleChoiceQuestions = createQuizInput.getMultipleChoiceQuestions();
-        // add other questions types here
-
-        assignNumbersIfNull(multipleChoiceQuestions);
-
-        List<QuestionEntity> allQuestions =
-                Stream.concat(
-                                multipleChoiceQuestions.stream().map(this::multipleChoiceQuestionInputToEntity),
-                                // add other questions types here
-                                Stream.empty())
-                        .sorted(comparing(QuestionEntity::getNumber))
-                        .toList();
-
-        QuizEntity entity = mapper.map(createQuizInput, QuizEntity.class);
-        entity.setQuestionPool(allQuestions);
-
-        return entity;
+        return mapper.map(createQuizInput, QuizEntity.class);
     }
 
     public QuestionEntity multipleChoiceQuestionInputToEntity(CreateMultipleChoiceQuestionInput input) {
@@ -71,22 +50,5 @@ public class QuizMapper {
         MultipleChoiceQuestionEntity result = mapper.map(input, MultipleChoiceQuestionEntity.class);
         result.setType(QuestionType.MULTIPLE_CHOICE);
         return result;
-    }
-
-    private void assignNumbersIfNull(List<CreateMultipleChoiceQuestionInput> createMultipleChoiceQuestionInputs) {
-        OptionalInt maxNumber = createMultipleChoiceQuestionInputs.stream()
-                .map(CreateMultipleChoiceQuestionInput::getNumber)
-                .filter(Objects::nonNull)
-                .mapToInt(Integer::intValue)
-                .max();
-
-        for (CreateMultipleChoiceQuestionInput createMultipleChoiceQuestionInput : createMultipleChoiceQuestionInputs) {
-            if (createMultipleChoiceQuestionInput.getNumber() == null) {
-                int newNumber = maxNumber.orElse(0) + 1;
-                createMultipleChoiceQuestionInput.setNumber(newNumber);
-                maxNumber = OptionalInt.of(newNumber);
-            }
-        }
-
     }
 }

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/service/QuizService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/service/QuizService.java
@@ -1,13 +1,9 @@
 package de.unistuttgart.iste.gits.quiz_service.service;
 
-import de.unistuttgart.iste.gits.common.event.ContentChangeEvent;
-import de.unistuttgart.iste.gits.common.event.CrudOperation;
-import de.unistuttgart.iste.gits.common.event.UserProgressLogEvent;
+import de.unistuttgart.iste.gits.common.event.*;
 import de.unistuttgart.iste.gits.generated.dto.*;
 import de.unistuttgart.iste.gits.quiz_service.dapr.TopicPublisher;
-import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuestionEntity;
-import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuestionStatisticEntity;
-import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
+import de.unistuttgart.iste.gits.quiz_service.persistence.dao.*;
 import de.unistuttgart.iste.gits.quiz_service.persistence.mapper.QuizMapper;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
 import de.unistuttgart.iste.gits.quiz_service.validation.QuizValidator;
@@ -101,12 +97,11 @@ public class QuizService {
         quizValidator.validateCreateMultipleChoiceQuestionInput(input);
 
         return modifyQuiz(quizId, entity -> {
-            if (input.getNumber() == null) {
-                assignNumber(input, entity);
-            }
-            checkNumberIsUnique(entity, input.getNumber());
+            int number = input.getNumber() == null ? assignNumber(entity) : input.getNumber();
+            checkNumberIsUnique(entity, number);
 
             QuestionEntity questionEntity = quizMapper.multipleChoiceQuestionInputToEntity(input);
+            questionEntity.setNumber(number);
             entity.getQuestionPool().add(questionEntity);
         });
     }
@@ -128,6 +123,49 @@ public class QuizService {
 
             int indexOfQuestion = entity.getQuestionPool().indexOf(questionEntity);
             entity.getQuestionPool().set(indexOfQuestion, quizMapper.multipleChoiceQuestionInputToEntity(input));
+        });
+    }
+
+    /**
+     * Adds a cloze question to a quiz.
+     *
+     * @param quizId the id of the quiz
+     * @param input  the question to add
+     * @return the modified quiz
+     * @throws EntityNotFoundException if the quiz does not exist
+     * @throws ValidationException     if input is invalid, see
+     *                                 {@link QuizValidator#validateCreateClozeQuestionInput(CreateClozeQuestionInput)}
+     */
+    public Quiz addClozeQuestion(UUID quizId, CreateClozeQuestionInput input) {
+        quizValidator.validateCreateClozeQuestionInput(input);
+
+        return modifyQuiz(quizId, entity -> {
+            int number = input.getNumber() == null ? assignNumber(entity) : input.getNumber();
+            checkNumberIsUnique(entity, number);
+
+            QuestionEntity questionEntity = quizMapper.clozeQuestionInputToEntity(input);
+            questionEntity.setNumber(number);
+            entity.getQuestionPool().add(questionEntity);
+        });
+    }
+
+    /**
+     * Updates a cloze question in a quiz.
+     *
+     * @param quizId the id of the quiz
+     * @param input  the updated question
+     * @return the modified quiz
+     * @throws EntityNotFoundException if the quiz or the question does not exist
+     * @throws ValidationException     if input is invalid, see
+     */
+    public Quiz updateClozeQuestion(UUID quizId, UpdateClozeQuestionInput input) {
+        quizValidator.validateUpdateClozeQuestionInput(input);
+
+        return modifyQuiz(quizId, entity -> {
+            QuestionEntity questionEntity = getQuestionInQuizById(entity, input.getId());
+
+            int indexOfQuestion = entity.getQuestionPool().indexOf(questionEntity);
+            entity.getQuestionPool().set(indexOfQuestion, quizMapper.clozeQuestionInputToEntity(input));
         });
     }
 
@@ -174,7 +212,6 @@ public class QuizService {
         });
     }
 
-
     public Quiz setRequiredCorrectAnswers(UUID quizId, int requiredCorrectAnswers) {
         return modifyQuiz(quizId, entity -> entity.setRequiredCorrectAnswers(requiredCorrectAnswers));
     }
@@ -220,9 +257,11 @@ public class QuizService {
         }
     }
 
-    private void assignNumber(CreateMultipleChoiceQuestionInput input, QuizEntity entity) {
-        int newNumber = entity.getQuestionPool().get(entity.getQuestionPool().size() - 1).getNumber() + 1;
-        input.setNumber(newNumber);
+    private int assignNumber(QuizEntity entity) {
+        if (entity.getQuestionPool().isEmpty()) {
+            return 1;
+        }
+        return entity.getQuestionPool().get(entity.getQuestionPool().size() - 1).getNumber() + 1;
     }
 
     private Quiz entityToDto(QuizEntity entity) {
@@ -285,7 +324,6 @@ public class QuizService {
      * @param dto event object containing changes to content
      */
     public void removeContentIds(ContentChangeEvent dto) {
-
         // validate event message
         try {
             checkCompletenessOfDto(dto);
@@ -317,6 +355,7 @@ public class QuizService {
             throw new NullPointerException("incomplete message received: all fields of a message must be non-null");
         }
     }
+
 
     /**
      * publishes user progress on a quiz to dapr topic
@@ -391,7 +430,7 @@ public class QuizService {
      * @param quizEntity     quizEntity source
      * @return calculated correctness value
      */
-    private double calcCorrectness(double correctAnswers, QuizEntity quizEntity) {
+    protected double calcCorrectness(double correctAnswers, QuizEntity quizEntity) {
         if (correctAnswers == 0.0) {
             return correctAnswers;
         }
@@ -410,5 +449,4 @@ public class QuizService {
         }
 
     }
-
 }

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/service/QuizService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/service/QuizService.java
@@ -224,10 +224,9 @@ public class QuizService {
         return modifyQuiz(quizId, entity -> entity.setNumberOfRandomlySelectedQuestions(numberOfRandomlySelectedQuestions));
     }
 
-    public void requireQuizExists(UUID id) {
-        if (!quizRepository.existsById(id)) {
-            throw new EntityNotFoundException("Quiz with id " + id + " not found");
-        }
+    public QuizEntity requireQuizExists(UUID id) {
+        return quizRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Quiz with id " + id + " not found"));
     }
 
     /**
@@ -240,8 +239,7 @@ public class QuizService {
      * @throws EntityNotFoundException if the quiz does not exist
      */
     private Quiz modifyQuiz(UUID quiz, Consumer<QuizEntity> modifier) {
-        requireQuizExists(quiz);
-        QuizEntity entity = quizRepository.findById(quiz).orElseThrow();
+        QuizEntity entity = requireQuizExists(quiz);
 
         modifier.accept(entity);
 

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/validation/QuizValidator.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/validation/QuizValidator.java
@@ -9,14 +9,7 @@ import java.util.List;
 @Component
 public class QuizValidator {
     public void validateCreateQuizInput(CreateQuizInput input) {
-        input.getMultipleChoiceQuestions().forEach(this::validateCreateMultipleChoiceQuestionInput);
-
-        List<Integer> allQuestionsNumbers = input.getMultipleChoiceQuestions()
-                .stream()
-                .map(CreateMultipleChoiceQuestionInput::getNumber)
-                .toList();
-
-        validateNumbersUnique(allQuestionsNumbers);
+        // no validation needed
     }
 
     public void validateCreateMultipleChoiceQuestionInput(CreateMultipleChoiceQuestionInput input) {
@@ -30,16 +23,6 @@ public class QuizValidator {
     private void validateAtLeastOneAnswerCorrect(List<MultipleChoiceAnswerInput> answers) {
         if (answers.stream().noneMatch(MultipleChoiceAnswerInput::getCorrect)) {
             throw new ValidationException("At least one answer must be correct");
-        }
-    }
-
-    private void validateNumbersUnique(List<Integer> numbers) {
-        if (numbers.size() != numbers.stream().distinct().count()) {
-            List<Integer> duplicateNumbers = numbers.stream()
-                    .filter(number -> numbers.stream().filter(number::equals).count() > 1)
-                    .toList();
-            throw new ValidationException("Question numbers must be unique, but the following numbers are used multiple times: "
-                                          + duplicateNumbers);
         }
     }
 }

--- a/src/main/java/de/unistuttgart/iste/gits/quiz_service/validation/QuizValidator.java
+++ b/src/main/java/de/unistuttgart/iste/gits/quiz_service/validation/QuizValidator.java
@@ -6,6 +6,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static de.unistuttgart.iste.gits.generated.dto.ClozeElementType.BLANK;
+import static de.unistuttgart.iste.gits.generated.dto.ClozeElementType.TEXT;
+
 @Component
 public class QuizValidator {
     public void validateCreateQuizInput(CreateQuizInput input) {
@@ -23,6 +26,43 @@ public class QuizValidator {
     private void validateAtLeastOneAnswerCorrect(List<MultipleChoiceAnswerInput> answers) {
         if (answers.stream().noneMatch(MultipleChoiceAnswerInput::getCorrect)) {
             throw new ValidationException("At least one answer must be correct");
+        }
+    }
+
+    public void validateCreateClozeQuestionInput(CreateClozeQuestionInput input) {
+        validateClozeElements(input.getClozeElements());
+    }
+
+    public void validateUpdateClozeQuestionInput(UpdateClozeQuestionInput input) {
+        validateClozeElements(input.getClozeElements());
+    }
+
+    private void validateClozeElements(List<ClozeElementInput> clozeElements) {
+        if (clozeElements.stream().map(ClozeElementInput::getType).noneMatch(BLANK::equals)) {
+            throw new ValidationException("Cloze quiz most contain at least one blank");
+        }
+        clozeElements.forEach(this::validateClozeElement);
+    }
+
+    private void validateClozeElement(ClozeElementInput clozeElement) {
+        if (clozeElement.getType() == BLANK) {
+            if (clozeElement.getCorrectAnswer() == null) {
+                throw new ValidationException("correct answer is required for cloze blank elements");
+            }
+            if (clozeElement.getText() != null) {
+                throw new ValidationException("text is not allowed for cloze blank elements");
+            }
+        }
+        if (clozeElement.getType() == TEXT) {
+            if (clozeElement.getCorrectAnswer() != null) {
+                throw new ValidationException("correct answer is not allowed for text elements");
+            }
+            if (clozeElement.getText() == null) {
+                throw new ValidationException("text is required for cloze text elements");
+            }
+            if (clozeElement.getFeedback() != null) {
+                throw new ValidationException("text elements cannot have feedback");
+            }
         }
     }
 }

--- a/src/main/resources/graphql/common/ResourceMarkdown.graphqls
+++ b/src/main/resources/graphql/common/ResourceMarkdown.graphqls
@@ -1,0 +1,17 @@
+type ResourceMarkdown {
+    """
+    The raw ResourceMarkdown text.
+    """
+    text: String!
+    """
+    Ids of MediaRecords referenced in the ResourceMarkdown text in order.
+    """
+    referencedMediaRecordIds: [UUID!]!
+}
+
+input ResourceMarkdownInput {
+    """
+    The raw ResourceMarkdown text.
+    """
+    text: String!
+}

--- a/src/main/resources/graphql/service/mutation.graphqls
+++ b/src/main/resources/graphql/service/mutation.graphqls
@@ -35,6 +35,42 @@ type QuizMutation {
     """
     updateMultipleChoiceQuestion(input: UpdateMultipleChoiceQuestionInput!): Quiz!
 
+    """
+    Add a cloze question to the quiz questions, at the end of the list.
+    """
+    addClozeQuestion(input: CreateClozeQuestionInput!): Quiz!
+    """
+    Update a cloze question in the quiz questions.
+    """
+    updateClozeQuestion(input: UpdateClozeQuestionInput!): Quiz!
+
+    """
+    Add an association question to the quiz questions, at the end of the list.
+    """
+    addAssociationQuestion(input: CreateAssociationQuestionInput!): Quiz!
+    """
+    Update an association question in the quiz questions.
+    """
+    updateAssociationQuestion(input: UpdateAssociationQuestionInput!): Quiz!
+
+    """
+    Add a free text question to the quiz questions, at the end of the list.
+    """
+    addFreeTextQuestion(input: CreateFreeTextQuestionInput!): Quiz!
+    """
+    Update a free text question in the quiz questions.
+    """
+    updateFreeTextQuestion(input: UpdateFreeTextQuestionInput!): Quiz!
+
+    """
+    Add a self assessment question to the quiz questions, at the end of the list.
+    """
+    addSelfAssessmentQuestion(input: CreateSelfAssessmentQuestionInput!): Quiz!
+    """
+    Update a self assessment question in the quiz questions.
+    """
+    updateSelfAssessmentQuestion(input: UpdateSelfAssessmentQuestionInput!): Quiz!
+
     # add other types of questions here
 
     """
@@ -89,13 +125,6 @@ input CreateQuizInput {
     If this is null or not set, the behavior is the same as if it was equal to the number of questions.
     """
     numberOfRandomlySelectedQuestions: Int @Positive
-
-    """
-    List of multiple choice questions.
-    """
-    multipleChoiceQuestions: [CreateMultipleChoiceQuestionInput!]! = []
-
-    # other types of questions
 }
 
 input CreateMultipleChoiceQuestionInput {
@@ -151,6 +180,210 @@ input MultipleChoiceAnswerInput {
     Feedback for when the user selects this answer, can be markdown.
     """
     feedback: String @Size(max: 1000)
+}
+
+input CreateClozeQuestionInput {
+    """
+    Number of the question, used for ordering.
+    This can be omitted, in which case a number, one higher than the highest number of the existing questions, will be used.
+    """
+    number: Int @Positive
+    """
+    Text of the question, can be markdown.
+    """
+    text: String! @Size(max: 1000)
+    """
+    List of cloze elements.
+    """
+    clozeElements: [ClozeElementInput!]! @ContainerSize(min: 1)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String @Size(max: 1000)
+}
+
+input UpdateClozeQuestionInput {
+    """
+    UUID of the question to update.
+    """
+    id: UUID!
+    """
+    Text of the question, can be markdown.
+    """
+    text: String! @Size(max: 1000)
+    """
+    List of cloze elements.
+    """
+    clozeElements: [ClozeElementInput!]! @ContainerSize(min: 1)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String @Size(max: 1000)
+}
+
+input ClozeElementInput {
+    """
+    Type of the element.
+    """
+    type: ClozeElementType!
+
+    """
+    Text of the element, can be markdown. Only used for TEXT type.
+    """
+    text: String! @Size(max: 1000)
+
+    """
+    The correct answer for the blank. Only used for BLANK type.
+    """
+    correctAnswer: String!
+    """
+    Wrong answers for the blank. Only used for BLANK type.
+    """
+    wrongAnswers: [String!]!
+    """
+    Feedback for the blank when the user selects a wrong answer, can be markdown. Only used for BLANK type.
+    """
+    feedback: String
+}
+
+input CreateAssociationQuestionInput {
+    """
+    Number of the question, used for ordering.
+    This can be omitted, in which case a number, one higher than the highest number of the existing questions, will be used.
+    """
+    number: Int @Positive
+    """
+    Text of the question, can be markdown.
+    """
+    text: String! @Size(max: 1000)
+    """
+    List of associations.
+    """
+    associations: [AssociationInput!]! @ContainerSize(min: 2)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String @Size(max: 1000)
+}
+
+input UpdateAssociationQuestionInput {
+    """
+    UUID of the question to update.
+    """
+    id: UUID!
+    """
+    Text of the question, can be markdown.
+    """
+    text: String! @Size(max: 1000)
+    """
+    List of associations.
+    """
+    associations: [AssociationInput!]! @ContainerSize(min: 2)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String @Size(max: 1000)
+}
+
+input AssociationInput {
+    """
+    Text of the left side of the association, can be markdown.
+    """
+    left: String! @Size(max: 255)
+    """
+    Text of the right side of the association, can be markdown.
+    """
+    right: String! @Size(max: 255)
+    """
+    Feedback for the association when the user selects a wrong answer, can be markdown.
+    """
+    feedback: String @Size(max: 1000)
+}
+
+input CreateFreeTextQuestionInput {
+    """
+    Number of the question, used for ordering.
+    This can be omitted, in which case a number, one higher than the highest number of the existing questions, will be used.
+    """
+    number: Int @Positive
+    """
+    Text of the question, can be markdown.
+    """
+    text: String! @Size(max: 1000)
+    """
+    A list of possible correct answers.
+    """
+    correctAnswers: [String!]! @ContainerSize(min: 1) @Size(max: 255)
+    """
+    Feedback for the question when the user enters a wrong answer, can be markdown.
+    """
+    feedback: String @Size(max: 1000)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String @Size(max: 1000)
+}
+
+input UpdateFreeTextQuestionInput {
+    """
+    UUID of the question to update.
+    """
+    id: UUID!
+    """
+    Text of the question, can be markdown.
+    """
+    text: String! @Size(max: 1000)
+    """
+    A list of possible correct answers.
+    """
+    correctAnswers: [String!]! @ContainerSize(min: 1) @Size(max: 255)
+    """
+    Feedback for the question when the user enters a wrong answer, can be markdown.
+    """
+    feedback: String @Size(max: 1000)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String @Size(max: 1000)
+}
+
+input CreateSelfAssessmentQuestionInput {
+    """
+    Number of the question, used for ordering.
+    This can be omitted, in which case a number, one higher than the highest number of the existing questions, will be used.
+    """
+    number: Int @Positive
+    """
+    Text of the question, can be markdown.
+    """
+    text: String! @Size(max: 1000)
+    """
+    A possible correct answer to the question.
+    """
+    solutionSuggestion: String! @Size(max: 1000)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String @Size(max: 1000)
+}
+
+input UpdateSelfAssessmentQuestionInput {
+    """
+    UUID of the question to update.
+    """
+    id: UUID!
+    """
+    Text of the question, can be markdown.
+    """
+    text: String! @Size(max: 1000)
+    """
+    A possible correct answer to the question.
+    """
+    solutionSuggestion: String! @Size(max: 1000)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String @Size(max: 1000)
 }
 
 input QuizCompletedInput {

--- a/src/main/resources/graphql/service/mutation.graphqls
+++ b/src/main/resources/graphql/service/mutation.graphqls
@@ -47,29 +47,37 @@ type QuizMutation {
     """
     Add an association question to the quiz questions, at the end of the list.
     """
-    addAssociationQuestion(input: CreateAssociationQuestionInput!): Quiz!
+    addAssociationQuestion(input: CreateAssociationQuestionInput!): Quiz! @deprecated(reason: "Not implemented yet")
     """
     Update an association question in the quiz questions.
     """
-    updateAssociationQuestion(input: UpdateAssociationQuestionInput!): Quiz!
+    updateAssociationQuestion(input: UpdateAssociationQuestionInput!): Quiz! @deprecated(reason: "Not implemented yet")
 
     """
-    Add a free text question to the quiz questions, at the end of the list.
+    Add an free text question with exact answer to the quiz questions, at the end of the list.
     """
-    addFreeTextQuestion(input: CreateFreeTextQuestionInput!): Quiz!
+    addExactAnswerQuestion(input: CreateExactAnswerQuestionInput!): Quiz! @deprecated(reason: "Not implemented yet")
     """
-    Update a free text question in the quiz questions.
+    Update an free text question with exact answer in the quiz questions.
     """
-    updateFreeTextQuestion(input: UpdateFreeTextQuestionInput!): Quiz!
+    updateExactAnswerQuestion(input: UpdateExactAnswerQuestionInput!): Quiz! @deprecated(reason: "Not implemented yet")
+    """
+    Add a numeric question to the quiz questions, at the end of the list.
+    """
+    addNumericQuestion(input: CreateNumericQuestionInput!): Quiz! @deprecated(reason: "Not implemented yet")
+    """
+    Update a numeric question in the quiz questions.
+    """
+    updateNumericQuestion(input: UpdateNumericQuestionInput!): Quiz! @deprecated(reason: "Not implemented yet")
 
     """
     Add a self assessment question to the quiz questions, at the end of the list.
     """
-    addSelfAssessmentQuestion(input: CreateSelfAssessmentQuestionInput!): Quiz!
+    addSelfAssessmentQuestion(input: CreateSelfAssessmentQuestionInput!): Quiz! @deprecated(reason: "Not implemented yet")
     """
     Update a self assessment question in the quiz questions.
     """
-    updateSelfAssessmentQuestion(input: UpdateSelfAssessmentQuestionInput!): Quiz!
+    updateSelfAssessmentQuestion(input: UpdateSelfAssessmentQuestionInput!): Quiz! @deprecated(reason: "Not implemented yet")
 
     # add other types of questions here
 
@@ -195,7 +203,11 @@ input CreateClozeQuestionInput {
     """
     List of additional wrong answers.
     """
-    additionalWrongAnswers: [String!]! @ContainerSize(min: 0) @Size(max: 255)
+    additionalWrongAnswers: [String!]! = [] @ContainerSize(min: 0) @Size(max: 255)
+    """
+    If true, the list of possible answers will be shown to the user.
+    """
+    showBlanksList: Boolean! = true
     """
     Optional hint for the question, can be markdown.
     """
@@ -216,6 +228,10 @@ input UpdateClozeQuestionInput {
     """
     additionalWrongAnswers: [String!]! @ContainerSize(min: 0) @Size(max: 255)
     """
+    If true, the list of possible answers will be shown to the user.
+    """
+    showBlanksList: Boolean! = true
+    """
     Optional hint for the question, can be markdown.
     """
     hint: ResourceMarkdownInput @Size(max: 1000)
@@ -230,12 +246,12 @@ input ClozeElementInput {
     """
     Text of the element. Only used for TEXT type.
     """
-    text: ResourceMarkdownInput!
+    text: ResourceMarkdownInput
 
     """
     The correct answer for the blank. Only used for BLANK type.
     """
-    correctAnswer: String!
+    correctAnswer: String @Size(max: 255)
     """
     Feedback for the blank when the user selects a wrong answer, can be markdown. Only used for BLANK type.
     """
@@ -296,7 +312,7 @@ input AssociationInput {
     feedback: ResourceMarkdownInput @Size(max: 1000)
 }
 
-input CreateFreeTextQuestionInput {
+input CreateExactAnswerQuestionInput {
     """
     Number of the question, used for ordering.
     This can be omitted, in which case a number, one higher than the highest number of the existing questions, will be used.
@@ -306,6 +322,10 @@ input CreateFreeTextQuestionInput {
     Text of the question, can be markdown.
     """
     text: ResourceMarkdownInput! @Size(max: 1000)
+    """
+    If the answer is case sensitive. If true, the answer is checked case sensitive.
+    """
+    caseSensitive: Boolean! = false
     """
     A list of possible correct answers.
     """
@@ -320,7 +340,7 @@ input CreateFreeTextQuestionInput {
     hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
-input UpdateFreeTextQuestionInput {
+input UpdateExactAnswerQuestionInput {
     """
     UUID of the question to update.
     """
@@ -333,6 +353,65 @@ input UpdateFreeTextQuestionInput {
     A list of possible correct answers.
     """
     correctAnswers: [String!]! @ContainerSize(min: 1) @Size(max: 255)
+    """
+    If the answer is case sensitive. If true, the answer is checked case sensitive.
+    """
+    caseSensitive: Boolean! = false
+    """
+    Feedback for the question when the user enters a wrong answer, can be markdown.
+    """
+    feedback: ResourceMarkdownInput @Size(max: 1000)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: ResourceMarkdownInput @Size(max: 1000)
+}
+
+input CreateNumericQuestionInput {
+    """
+    Number of the question, used for ordering.
+    This can be omitted, in which case a number, one higher than the highest number of the existing questions, will be used.
+    """
+    number: Int @Positive
+    """
+    Text of the question, can be markdown.
+    """
+    text: ResourceMarkdownInput! @Size(max: 1000)
+    """
+    The correct answer for the question.
+    """
+    correctAnswer: Float!
+    """
+    The allowed deviation from the correct answer.
+    """
+    tolerance: Float! @Positive
+    """
+    Feedback for the question when the user enters a wrong answer, can be markdown.
+    """
+    feedback: ResourceMarkdownInput @Size(max: 1000)
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: ResourceMarkdownInput @Size(max: 1000)
+}
+
+input UpdateNumericQuestionInput {
+    """
+    UUID of the question to update.
+    """
+    id: UUID!
+    """
+    Text of the question, can be markdown.
+    """
+    text: ResourceMarkdownInput! @Size(max: 1000)
+    """
+    The correct answer for the question.
+    """
+    correctAnswer: Float!
+    """
+    The allowed deviation from the correct answer.
+    """
+    tolerance: Float! @Positive
     """
     Feedback for the question when the user enters a wrong answer, can be markdown.
     """

--- a/src/main/resources/graphql/service/mutation.graphqls
+++ b/src/main/resources/graphql/service/mutation.graphqls
@@ -136,7 +136,7 @@ input CreateMultipleChoiceQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: ResourceMarkdownInput! @Size(max: 1000)
+    text: ResourceMarkdownInput!
     """
     List of answers.
     """
@@ -144,7 +144,7 @@ input CreateMultipleChoiceQuestionInput {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput
 }
 
 input UpdateMultipleChoiceQuestionInput {
@@ -155,7 +155,7 @@ input UpdateMultipleChoiceQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: ResourceMarkdownInput! @Size(max: 1000)
+    text: ResourceMarkdownInput!
     """
     List of answers.
     """
@@ -163,7 +163,7 @@ input UpdateMultipleChoiceQuestionInput {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput
 
 }
 
@@ -171,7 +171,7 @@ input MultipleChoiceAnswerInput {
     """
     Text of the answer, can be markdown.
     """
-    text: ResourceMarkdownInput! @Size(max: 1000)
+    answerText: ResourceMarkdownInput!
     """
     Whether the answer is correct or not.
     """
@@ -179,7 +179,7 @@ input MultipleChoiceAnswerInput {
     """
     Feedback for when the user selects this answer, can be markdown.
     """
-    feedback: String @Size(max: 1000)
+    feedback: ResourceMarkdownInput
 }
 
 input CreateClozeQuestionInput {
@@ -228,9 +228,9 @@ input ClozeElementInput {
     type: ClozeElementType!
 
     """
-    Text of the element, can be markdown. Only used for TEXT type.
+    Text of the element. Only used for TEXT type.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput!
 
     """
     The correct answer for the blank. Only used for BLANK type.

--- a/src/main/resources/graphql/service/mutation.graphqls
+++ b/src/main/resources/graphql/service/mutation.graphqls
@@ -136,7 +136,7 @@ input CreateMultipleChoiceQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     List of answers.
     """
@@ -155,7 +155,7 @@ input UpdateMultipleChoiceQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     List of answers.
     """
@@ -171,7 +171,7 @@ input MultipleChoiceAnswerInput {
     """
     Text of the answer, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     Whether the answer is correct or not.
     """
@@ -189,17 +189,17 @@ input CreateClozeQuestionInput {
     """
     number: Int @Positive
     """
-    Text of the question, can be markdown.
-    """
-    text: String! @Size(max: 1000)
-    """
     List of cloze elements.
     """
     clozeElements: [ClozeElementInput!]! @ContainerSize(min: 1)
     """
+    List of additional wrong answers.
+    """
+    additionalWrongAnswers: [String!]! @ContainerSize(min: 0) @Size(max: 255)
+    """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input UpdateClozeQuestionInput {
@@ -208,17 +208,17 @@ input UpdateClozeQuestionInput {
     """
     id: UUID!
     """
-    Text of the question, can be markdown.
-    """
-    text: String! @Size(max: 1000)
-    """
     List of cloze elements.
     """
     clozeElements: [ClozeElementInput!]! @ContainerSize(min: 1)
     """
+    List of additional wrong answers.
+    """
+    additionalWrongAnswers: [String!]! @ContainerSize(min: 0) @Size(max: 255)
+    """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input ClozeElementInput {
@@ -237,13 +237,9 @@ input ClozeElementInput {
     """
     correctAnswer: String!
     """
-    Wrong answers for the blank. Only used for BLANK type.
-    """
-    wrongAnswers: [String!]!
-    """
     Feedback for the blank when the user selects a wrong answer, can be markdown. Only used for BLANK type.
     """
-    feedback: String
+    feedback: ResourceMarkdownInput
 }
 
 input CreateAssociationQuestionInput {
@@ -255,7 +251,7 @@ input CreateAssociationQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     List of associations.
     """
@@ -263,7 +259,7 @@ input CreateAssociationQuestionInput {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input UpdateAssociationQuestionInput {
@@ -274,7 +270,7 @@ input UpdateAssociationQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     List of associations.
     """
@@ -282,7 +278,7 @@ input UpdateAssociationQuestionInput {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input AssociationInput {
@@ -297,7 +293,7 @@ input AssociationInput {
     """
     Feedback for the association when the user selects a wrong answer, can be markdown.
     """
-    feedback: String @Size(max: 1000)
+    feedback: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input CreateFreeTextQuestionInput {
@@ -309,7 +305,7 @@ input CreateFreeTextQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     A list of possible correct answers.
     """
@@ -317,11 +313,11 @@ input CreateFreeTextQuestionInput {
     """
     Feedback for the question when the user enters a wrong answer, can be markdown.
     """
-    feedback: String @Size(max: 1000)
+    feedback: ResourceMarkdownInput @Size(max: 1000)
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input UpdateFreeTextQuestionInput {
@@ -332,7 +328,7 @@ input UpdateFreeTextQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     A list of possible correct answers.
     """
@@ -340,11 +336,11 @@ input UpdateFreeTextQuestionInput {
     """
     Feedback for the question when the user enters a wrong answer, can be markdown.
     """
-    feedback: String @Size(max: 1000)
+    feedback: ResourceMarkdownInput @Size(max: 1000)
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input CreateSelfAssessmentQuestionInput {
@@ -356,15 +352,15 @@ input CreateSelfAssessmentQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     A possible correct answer to the question.
     """
-    solutionSuggestion: String! @Size(max: 1000)
+    solutionSuggestion: ResourceMarkdownInput! @Size(max: 1000)
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input UpdateSelfAssessmentQuestionInput {
@@ -375,15 +371,15 @@ input UpdateSelfAssessmentQuestionInput {
     """
     Text of the question, can be markdown.
     """
-    text: String! @Size(max: 1000)
+    text: ResourceMarkdownInput! @Size(max: 1000)
     """
     A possible correct answer to the question.
     """
-    solutionSuggestion: String! @Size(max: 1000)
+    solutionSuggestion: ResourceMarkdownInput! @Size(max: 1000)
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String @Size(max: 1000)
+    hint: ResourceMarkdownInput @Size(max: 1000)
 }
 
 input QuizCompletedInput {

--- a/src/main/resources/graphql/service/quiz.graphqls
+++ b/src/main/resources/graphql/service/quiz.graphqls
@@ -140,6 +140,10 @@ type ClozeQuestion implements Question {
     """
     clozeElements: [ClozeElement!]!
     """
+    Addtional wrong answers for the blanks.
+    """
+    additionalWrongAnswers: [String!]!
+    """
     All selectable answers for the blanks (computed). This contains the correct answers as well as wrong answers.
     """
     allBlanks: [String!]!
@@ -194,10 +198,6 @@ type ClozeBlankElement implements ClozeElement {
     The correct answer for the blank.
     """
     correctAnswer: String!
-    """
-    Wrong answers for the blank.
-    """
-    wrongAnswers: [String!]!
     """
     Feedback for the blank when the user selects a wrong answer, can be markdown.
     """

--- a/src/main/resources/graphql/service/quiz.graphqls
+++ b/src/main/resources/graphql/service/quiz.graphqls
@@ -123,7 +123,7 @@ type MultipleChoiceAnswer {
     """
     Text of the answer, can be markdown.
     """
-    text: ResourceMarkdown!
+    answerText: ResourceMarkdown!
     """
     Whether the answer is correct or not.
     """

--- a/src/main/resources/graphql/service/quiz.graphqls
+++ b/src/main/resources/graphql/service/quiz.graphqls
@@ -172,28 +172,16 @@ type ClozeQuestion implements Question {
     hint: ResourceMarkdown
 }
 
+union ClozeElement = ClozeTextElement | ClozeBlankElement
 
-interface ClozeElement {
-    """
-    Type of the element.
-    """
-    type: ClozeElementType!
-}
-
-type ClozeTextElement implements ClozeElement {
+type ClozeTextElement {
     """
     Text of the element, can be markdown.
     """
     text: ResourceMarkdown!
-
-    # inherited from ClozeElement
-    """
-    Type of the element. Must be TEXT.
-    """
-    type: ClozeElementType!
 }
 
-type ClozeBlankElement implements ClozeElement {
+type ClozeBlankElement {
     """
     The correct answer for the blank.
     """
@@ -202,12 +190,6 @@ type ClozeBlankElement implements ClozeElement {
     Feedback for the blank when the user selects a wrong answer, can be markdown.
     """
     feedback: ResourceMarkdown
-
-    # inherited from ClozeElement
-    """
-    Type of the element. Must be BLANK.
-    """
-    type: ClozeElementType!
 }
 
 enum ClozeElementType {

--- a/src/main/resources/graphql/service/quiz.graphqls
+++ b/src/main/resources/graphql/service/quiz.graphqls
@@ -76,7 +76,7 @@ interface Question {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String
+    hint: ResourceMarkdown
 }
 
 """
@@ -86,7 +86,7 @@ type MultipleChoiceQuestion implements Question {
     """
     Text of the question, can be markdown.
     """
-    text: String!
+    text: ResourceMarkdown!
     """
     List of answers.
     """
@@ -116,14 +116,14 @@ type MultipleChoiceQuestion implements Question {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String
+    hint: ResourceMarkdown
 }
 
 type MultipleChoiceAnswer {
     """
     Text of the answer, can be markdown.
     """
-    text: String!
+    text: ResourceMarkdown!
     """
     Whether the answer is correct or not.
     """
@@ -131,7 +131,7 @@ type MultipleChoiceAnswer {
     """
     Feedback for when the user selects this answer, can be markdown.
     """
-    feedback: String
+    feedback: ResourceMarkdown
 }
 
 type ClozeQuestion implements Question {
@@ -165,7 +165,7 @@ type ClozeQuestion implements Question {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String
+    hint: ResourceMarkdown
 }
 
 
@@ -180,7 +180,7 @@ type ClozeTextElement implements ClozeElement {
     """
     Text of the element, can be markdown.
     """
-    text: String!
+    text: ResourceMarkdown!
 
     # inherited from ClozeElement
     """
@@ -201,7 +201,7 @@ type ClozeBlankElement implements ClozeElement {
     """
     Feedback for the blank when the user selects a wrong answer, can be markdown.
     """
-    feedback: String
+    feedback: ResourceMarkdown
 
     # inherited from ClozeElement
     """
@@ -222,7 +222,7 @@ type AssociationQuestion implements Question {
     """
     Text to display above the assignment question, can be markdown.
     """
-    text: String!
+    text: ResourceMarkdown!
     """
     List of correct associations.
     """
@@ -253,7 +253,7 @@ type AssociationQuestion implements Question {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String
+    hint: ResourceMarkdown
 }
 
 type SingleAssociation {
@@ -269,7 +269,7 @@ type SingleAssociation {
     """
     Feedback for the assignment when the user assigns a wrong answer, can be markdown.
     """
-    feedback: String
+    feedback: ResourceMarkdown
 }
 
 """
@@ -277,19 +277,23 @@ A question with a clear, correct answer that can be automatically checked.
 Differs from self-assessment questions in that the user has to enter one of the correct answers and
 the answer is checked automatically.
 """
-type FreeTextQuestion {
+type ExactAnswerQuestion implements Question {
     """
     Text of the question, can be markdown.
     """
-    text: String!
+    text: ResourceMarkdown!
     """
-    A list of possible correct answers.
+    A list of possible correct answers. The user has to enter one of these answers.
     """
     correctAnswers: [String!]!
     """
+    If the answer is case sensitive. If true, the answer is checked case sensitive.
+    """
+    isCaseSensitive: Boolean!
+    """
     Feedback for the question when the user enters a wrong answer, can be markdown.
     """
-    feedback: String
+    feedback: ResourceMarkdown
 
     # inherited from Question
     """
@@ -308,7 +312,47 @@ type FreeTextQuestion {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String
+    hint: ResourceMarkdown
+}
+
+type NumericQuestion implements Question {
+    """
+    Text of the question, can be markdown.
+    """
+    text: ResourceMarkdown!
+    """
+    The correct answer to the question.
+    """
+    correctAnswer: Float!
+    """
+    The number of decimal places to consider when checking the answer.
+    Both the correct answer and the user's answer are rounded to this number of decimal places.
+    """
+    decimalPlaces: Int!
+
+    """
+    Feedback for the question when the user enters a wrong answer, can be markdown.
+    """
+    feedback: ResourceMarkdown
+
+    # inherited from Question
+    """
+    Unique identifier of the question.
+    """
+    id: UUID!
+    """
+    Number of the question, i.e., the position of the question in the list of questions.
+    Only relevant if questionPoolingMode is ORDERED.
+    """
+    number: Int!
+    """
+    Type of the question.
+    """
+    type: QuestionType!
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: ResourceMarkdown
 }
 
 """
@@ -320,11 +364,11 @@ type SelfAssessmentQuestion {
     """
     Text of the question, can be markdown.
     """
-    text: String!
+    text: ResourceMarkdown!
     """
     A possible correct answer to the question.
     """
-    solutionSuggestion: String!
+    solutionSuggestion: ResourceMarkdown!
 
     # inherited from Question
     """
@@ -343,7 +387,7 @@ type SelfAssessmentQuestion {
     """
     Optional hint for the question, can be markdown.
     """
-    hint: String
+    hint: ResourceMarkdown
 }
 
 """
@@ -353,7 +397,8 @@ enum QuestionType {
     MULTIPLE_CHOICE
     CLOZE
     ASSIGNMENT
-    FREE_TEXT
+    EXACT_ANSWER
+    NUMERIC_QUESTION
     SELF_ASSESSMENT
     # add more types here
 }

--- a/src/main/resources/graphql/service/quiz.graphqls
+++ b/src/main/resources/graphql/service/quiz.graphqls
@@ -134,10 +134,226 @@ type MultipleChoiceAnswer {
     feedback: String
 }
 
+type ClozeQuestion implements Question {
+    """
+    The elements of the cloze question.
+    """
+    clozeElements: [ClozeElement!]!
+    """
+    All selectable answers for the blanks (computed). This contains the correct answers as well as wrong answers.
+    """
+    allBlanks: [String!]!
+    """
+    Whether the blanks must be answered in free text or by selecting the correct answer from a list.
+    """
+    showBlanksList: Boolean!
+
+    # inherited from Question
+    """
+    Unique identifier of the question.
+    """
+    id: UUID!
+    """
+    Number of the question, i.e., the position of the question in the list of questions.
+    Only relevant if questionPoolingMode is ORDERED.
+    """
+    number: Int!
+    """
+    Type of the question.
+    """
+    type: QuestionType!
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String
+}
+
+
+interface ClozeElement {
+    """
+    Type of the element.
+    """
+    type: ClozeElementType!
+}
+
+type ClozeTextElement implements ClozeElement {
+    """
+    Text of the element, can be markdown.
+    """
+    text: String!
+
+    # inherited from ClozeElement
+    """
+    Type of the element. Must be TEXT.
+    """
+    type: ClozeElementType!
+}
+
+type ClozeBlankElement implements ClozeElement {
+    """
+    The correct answer for the blank.
+    """
+    correctAnswer: String!
+    """
+    Wrong answers for the blank.
+    """
+    wrongAnswers: [String!]!
+    """
+    Feedback for the blank when the user selects a wrong answer, can be markdown.
+    """
+    feedback: String
+
+    # inherited from ClozeElement
+    """
+    Type of the element. Must be BLANK.
+    """
+    type: ClozeElementType!
+}
+
+enum ClozeElementType {
+    TEXT
+    BLANK
+}
+
+"""
+Association question, i.e., a question where the user has to assign the correct right side to each left side.
+"""
+type AssociationQuestion implements Question {
+    """
+    Text to display above the assignment question, can be markdown.
+    """
+    text: String!
+    """
+    List of correct associations.
+    """
+    correctAssociations: [SingleAssociation!]!
+    """
+    Computed list of all the left sides of the associations, shuffled.
+    """
+    leftSide: [String!]!
+    """
+    Computed list of all the right sides of the associations, shuffled.
+    """
+    rightSide: [String!]!
+
+    # inherited from Question
+    """
+    Unique identifier of the question.
+    """
+    id: UUID!
+    """
+    Number of the question, i.e., the position of the question in the list of questions.
+    Only relevant if questionPoolingMode is ORDERED.
+    """
+    number: Int!
+    """
+    Type of the question.
+    """
+    type: QuestionType!
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String
+}
+
+type SingleAssociation {
+    """
+    The left side of the assignment.
+    """
+    left: String!
+    """
+    The right side of the assignment.
+    """
+    right: String!
+
+    """
+    Feedback for the assignment when the user assigns a wrong answer, can be markdown.
+    """
+    feedback: String
+}
+
+"""
+A question with a clear, correct answer that can be automatically checked.
+Differs from self-assessment questions in that the user has to enter one of the correct answers and
+the answer is checked automatically.
+"""
+type FreeTextQuestion {
+    """
+    Text of the question, can be markdown.
+    """
+    text: String!
+    """
+    A list of possible correct answers.
+    """
+    correctAnswers: [String!]!
+    """
+    Feedback for the question when the user enters a wrong answer, can be markdown.
+    """
+    feedback: String
+
+    # inherited from Question
+    """
+    Unique identifier of the question.
+    """
+    id: UUID!
+    """
+    Number of the question, i.e., the position of the question in the list of questions.
+    Only relevant if questionPoolingMode is ORDERED.
+    """
+    number: Int!
+    """
+    Type of the question.
+    """
+    type: QuestionType!
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String
+}
+
+"""
+A single question with a free text answer field, where the answer is not automatically checked.
+The user has to enter a solution and self-assess whether it is correct or not.
+This is useful for questions where the answer is not clear-cut, e.g. when the user should explain a concept.
+"""
+type SelfAssessmentQuestion {
+    """
+    Text of the question, can be markdown.
+    """
+    text: String!
+    """
+    A possible correct answer to the question.
+    """
+    solutionSuggestion: String!
+
+    # inherited from Question
+    """
+    Unique identifier of the question.
+    """
+    id: UUID!
+    """
+    Number of the question, i.e., the position of the question in the list of questions.
+    Only relevant if questionPoolingMode is ORDERED.
+    """
+    number: Int!
+    """
+    Type of the question.
+    """
+    type: QuestionType!
+    """
+    Optional hint for the question, can be markdown.
+    """
+    hint: String
+}
+
 """
 The type of a question.
 """
 enum QuestionType {
     MULTIPLE_CHOICE
+    CLOZE
+    ASSIGNMENT
+    FREE_TEXT
+    SELF_ASSESSMENT
     # add more types here
 }

--- a/src/main/resources/graphql/service/quiz.graphqls
+++ b/src/main/resources/graphql/service/quiz.graphqls
@@ -202,7 +202,7 @@ Association question, i.e., a question where the user has to assign the correct 
 """
 type AssociationQuestion implements Question {
     """
-    Text to display above the assignment question, can be markdown.
+    Text to display above the association question, can be markdown.
     """
     text: ResourceMarkdown!
     """
@@ -240,16 +240,16 @@ type AssociationQuestion implements Question {
 
 type SingleAssociation {
     """
-    The left side of the assignment.
+    The left side of the association.
     """
     left: String!
     """
-    The right side of the assignment.
+    The right side of the association.
     """
     right: String!
 
     """
-    Feedback for the assignment when the user assigns a wrong answer, can be markdown.
+    Feedback for the association when the user assigns a wrong answer, can be markdown.
     """
     feedback: ResourceMarkdown
 }
@@ -271,7 +271,7 @@ type ExactAnswerQuestion implements Question {
     """
     If the answer is case sensitive. If true, the answer is checked case sensitive.
     """
-    isCaseSensitive: Boolean!
+    caseSensitive: Boolean!
     """
     Feedback for the question when the user enters a wrong answer, can be markdown.
     """
@@ -307,10 +307,9 @@ type NumericQuestion implements Question {
     """
     correctAnswer: Float!
     """
-    The number of decimal places to consider when checking the answer.
-    Both the correct answer and the user's answer are rounded to this number of decimal places.
+    The tolerance for the correct answer. The user's answer is correct if it is within the tolerance of the correct answer.
     """
-    decimalPlaces: Int!
+    tolerance: Float!
 
     """
     Feedback for the question when the user enters a wrong answer, can be markdown.
@@ -342,7 +341,7 @@ A single question with a free text answer field, where the answer is not automat
 The user has to enter a solution and self-assess whether it is correct or not.
 This is useful for questions where the answer is not clear-cut, e.g. when the user should explain a concept.
 """
-type SelfAssessmentQuestion {
+type SelfAssessmentQuestion implements Question {
     """
     Text of the question, can be markdown.
     """
@@ -378,9 +377,9 @@ The type of a question.
 enum QuestionType {
     MULTIPLE_CHOICE
     CLOZE
-    ASSIGNMENT
+    ASSOCIATION
     EXACT_ANSWER
-    NUMERIC_QUESTION
+    NUMERIC
     SELF_ASSESSMENT
     # add more types here
 }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/TestData.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/TestData.java
@@ -2,12 +2,10 @@ package de.unistuttgart.iste.gits.quiz_service;
 
 import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
 import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
-import de.unistuttgart.iste.gits.generated.dto.QuestionPoolingMode;
-import de.unistuttgart.iste.gits.generated.dto.QuestionType;
+import de.unistuttgart.iste.gits.generated.dto.*;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.*;
 
-import java.util.Arrays;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Stream;
 
 public class TestData {
@@ -27,22 +25,103 @@ public class TestData {
 
         var builder = MultipleChoiceQuestionEntity.builder()
                 .type(QuestionType.MULTIPLE_CHOICE)
+                .hint(new ResourceMarkdownEntity("hint"))
                 .number(number)
                 .text(new ResourceMarkdownEmbeddable(text));
 
         var correctAnswer = MultipleChoiceAnswerEmbeddable.builder()
                 .answerText(new ResourceMarkdownEntity(correctAnswerText))
+                .feedback(new ResourceMarkdownEntity("feedback"))
                 .correct(true)
                 .build();
 
         var wrongAnswers = Arrays.stream(wrongAnswerText)
                 .map(answer -> MultipleChoiceAnswerEmbeddable.builder()
                         .answerText(new ResourceMarkdownEntity(answer))
+                        .feedback(new ResourceMarkdownEntity("feedback"))
                         .correct(false)
                         .build());
 
         builder.answers(Stream.concat(Stream.of(correctAnswer), wrongAnswers).toList());
 
         return builder.build();
+    }
+
+    public static ClozeQuestionEntity createClozeQuestion(int number, ClozeElementEmbeddable... clozeElements) {
+        return ClozeQuestionEntity.builder()
+                .type(QuestionType.CLOZE)
+                .number(number)
+                .showBlanksList(true)
+                .additionalWrongAnswers(Arrays.asList("wrong1", "wrong2"))
+                .clozeElements(Arrays.asList(clozeElements))
+                .hint(new ResourceMarkdownEntity("hint"))
+                .build();
+    }
+
+    public static ClozeElementEmbeddable clozeText(String text) {
+        return ClozeElementEmbeddable.builder()
+                .type(ClozeElementType.TEXT)
+                .text(new ResourceMarkdownEmbeddable(text))
+                .build();
+    }
+
+    public static ClozeElementEmbeddable clozeBlank(String correctAnswer) {
+        return ClozeElementEmbeddable.builder()
+                .type(ClozeElementType.BLANK)
+                .correctAnswer(correctAnswer)
+                .feedback(new ResourceMarkdownEntity("feedback"))
+                .build();
+    }
+
+    public static AssociationQuestionEntity createAssociationQuestion(int number, AssociationEmbeddable... associations) {
+        return AssociationQuestionEntity.builder()
+                .type(QuestionType.ASSOCIATION)
+                .number(number)
+                .text(new ResourceMarkdownEmbeddable("text"))
+                .correctAssociations(Arrays.asList(associations))
+                .hint(new ResourceMarkdownEntity("hint"))
+                .build();
+    }
+
+    public static AssociationEmbeddable association(String left, String right) {
+        return AssociationEmbeddable.builder()
+                .left(left)
+                .right(right)
+                .feedback(new ResourceMarkdownEmbeddable("feedback"))
+                .build();
+    }
+
+    public static ExactAnswerQuestionEntity createExactAnswerQuestion(int number, String question, String answer) {
+        return ExactAnswerQuestionEntity.builder()
+                .type(QuestionType.EXACT_ANSWER)
+                .number(number)
+                .text(new ResourceMarkdownEmbeddable(question))
+                .correctAnswers(Collections.singletonList(answer))
+                .feedback(new ResourceMarkdownEntity("feedback"))
+                .caseSensitive(true)
+                .hint(new ResourceMarkdownEntity("hint"))
+                .build();
+    }
+
+    public static NumericQuestionEntity createNumericQuestion(int number, String question, double answer) {
+        return NumericQuestionEntity.builder()
+                .type(QuestionType.NUMERIC)
+                .number(number)
+                .text(new ResourceMarkdownEmbeddable(question))
+                .feedback(new ResourceMarkdownEntity("feedback"))
+                .tolerance(1)
+                .correctAnswer(answer)
+                .hint(new ResourceMarkdownEntity("hint"))
+                .build();
+    }
+
+    public static SelfAssessmentQuestionEntity createSelfAssessmentQuestion(int number, String question, String answer) {
+        return SelfAssessmentQuestionEntity.builder()
+                .type(QuestionType.SELF_ASSESSMENT)
+                .number(number)
+                .text(new ResourceMarkdownEmbeddable(question))
+                .solutionSuggestion(new ResourceMarkdownEntity(answer))
+                .hint(new ResourceMarkdownEntity("hint"))
+                .build();
     }
 }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/TestData.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/TestData.java
@@ -1,5 +1,7 @@
 package de.unistuttgart.iste.gits.quiz_service;
 
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
 import de.unistuttgart.iste.gits.generated.dto.QuestionPoolingMode;
 import de.unistuttgart.iste.gits.generated.dto.QuestionType;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.*;
@@ -26,16 +28,16 @@ public class TestData {
         var builder = MultipleChoiceQuestionEntity.builder()
                 .type(QuestionType.MULTIPLE_CHOICE)
                 .number(number)
-                .text(text);
+                .text(new ResourceMarkdownEmbeddable(text));
 
         var correctAnswer = MultipleChoiceAnswerEmbeddable.builder()
-                .text(correctAnswerText)
+                .answerText(new ResourceMarkdownEntity(correctAnswerText))
                 .correct(true)
                 .build();
 
         var wrongAnswers = Arrays.stream(wrongAnswerText)
                 .map(answer -> MultipleChoiceAnswerEmbeddable.builder()
-                        .text(answer)
+                        .answerText(new ResourceMarkdownEntity(answer))
                         .correct(false)
                         .build());
 

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/QuizFragments.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/QuizFragments.java
@@ -1,21 +1,68 @@
 package de.unistuttgart.iste.gits.quiz_service.api;
 
+/**
+ * This class contains GraphQL fragments for quiz queries.
+ */
 public class QuizFragments {
 
+    /**
+     * GraphQL fragment for all fields of a quiz.
+     */
     public static final String FRAGMENT_DEFINITION = """
                         
             fragment QuestionsAllFields on Question {
                 id
                 number
                 type
-                hint { text }
+                hint { text referencedMediaRecordIds }
                 ... on MultipleChoiceQuestion {
-                    text { text }
+                    text { text referencedMediaRecordIds }
                     answers {
-                        answerText { text }
+                        answerText { text referencedMediaRecordIds }
                         correct
-                        feedback { text }
+                        feedback { text referencedMediaRecordIds }
                     }
+                    numberOfCorrectAnswers
+                }
+                ... on ClozeQuestion {
+                    showBlanksList
+                    clozeElements {
+                        ... on ClozeBlankElement {
+                            correctAnswer
+                            feedback { text referencedMediaRecordIds }
+                        }
+                        ... on ClozeTextElement {
+                            text { text referencedMediaRecordIds }
+                        }
+                    }
+                    additionalWrongAnswers
+                    allBlanks
+                }
+                ... on AssociationQuestion {
+                    text { text referencedMediaRecordIds }
+                    correctAssociations {
+                        left
+                        right
+                        feedback { text referencedMediaRecordIds }
+                    }
+                    leftSide
+                    rightSide
+                }
+                ... on ExactAnswerQuestion {
+                    text { text referencedMediaRecordIds }
+                    correctAnswers
+                    caseSensitive
+                    feedback { text referencedMediaRecordIds }
+                }
+                ... on NumericQuestion {
+                    text { text referencedMediaRecordIds }
+                    correctAnswer
+                    tolerance
+                    feedback { text referencedMediaRecordIds }
+                }
+                ... on SelfAssessmentQuestion {
+                    text { text referencedMediaRecordIds }
+                    solutionSuggestion { text referencedMediaRecordIds }
                 }
             }
                         
@@ -25,6 +72,9 @@ public class QuizFragments {
                 questionPoolingMode
                 numberOfRandomlySelectedQuestions
                 questionPool {
+                    ...QuestionsAllFields
+                }
+                selectedQuestions {
                     ...QuestionsAllFields
                 }
             }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/QuizFragments.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/QuizFragments.java
@@ -1,0 +1,35 @@
+package de.unistuttgart.iste.gits.quiz_service.api;
+
+public class QuizFragments {
+
+    public static final String FRAGMENT_DEFINITION = """
+                        
+            fragment QuestionsAllFields on Question {
+                id
+                number
+                type
+                hint { text }
+                ... on MultipleChoiceQuestion {
+                    text { text }
+                    answers {
+                        answerText { text }
+                        correct
+                        feedback { text }
+                    }
+                }
+            }
+                        
+            fragment QuizAllFields on Quiz {
+                assessmentId
+                requiredCorrectAnswers
+                questionPoolingMode
+                numberOfRandomlySelectedQuestions
+                questionPool {
+                    ...QuestionsAllFields
+                }
+            }
+                        
+            """;
+
+
+}

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/CreateQuizMutationTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/CreateQuizMutationTest.java
@@ -3,6 +3,7 @@ package de.unistuttgart.iste.gits.quiz_service.api.mutation;
 import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
 import de.unistuttgart.iste.gits.generated.dto.*;
+import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
@@ -13,10 +14,10 @@ import org.springframework.test.annotation.Commit;
 import java.util.List;
 import java.util.UUID;
 
-import static de.unistuttgart.iste.gits.quiz_service.matcher.MultipleChoiceQuestionDtoToCreateInputMatcher.matchesInput;
 import static de.unistuttgart.iste.gits.quiz_service.matcher.QuizEntityToCreateInputMatcher.matchesCreateQuizInput;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 
 @GraphQlApiTest
 @TablesToDelete({"multiple_choice_question_answers", "multiple_choice_question", "quiz_question_pool", "question", "quiz"})
@@ -39,29 +40,12 @@ class CreateQuizMutationTest {
                 .setRequiredCorrectAnswers(1)
                 .setQuestionPoolingMode(QuestionPoolingMode.RANDOM)
                 .setNumberOfRandomlySelectedQuestions(2)
-                .setMultipleChoiceQuestions(List.of())
                 .build();
 
-        String query = """
+        String query = QuizFragments.FRAGMENT_DEFINITION + """
                 mutation createQuiz($id: UUID!, $input: CreateQuizInput!) {
                     createQuiz(assessmentId: $id, input: $input) {
-                        assessmentId
-                        requiredCorrectAnswers
-                        questionPoolingMode
-                        numberOfRandomlySelectedQuestions
-                        questionPool {
-                            number
-                            hint
-                            type
-                            ... on MultipleChoiceQuestion {
-                                text
-                                answers {
-                                    text
-                                    correct
-                                    feedback
-                                }
-                            }
-                        }
+                        ...QuizAllFields
                     }
                 }""";
 
@@ -92,173 +76,5 @@ class CreateQuizMutationTest {
 
         assertThat(quizRepository.count(), is(1L));
         assertThat(quizRepository.findAll().get(0), matchesCreateQuizInput(createQuizInput));
-    }
-
-    /**
-     * Given a quiz with two questions
-     * When the "createQuiz" mutation is executed
-     * Then the quiz is created
-     */
-    @Test
-    @Transactional
-    @Commit
-    void testCreateQuizWithQuestions(GraphQlTester graphQlTester) {
-        UUID assessmentId = UUID.randomUUID();
-        CreateQuizInput createQuizInput = CreateQuizInput.builder()
-                .setRequiredCorrectAnswers(1)
-                .setQuestionPoolingMode(QuestionPoolingMode.RANDOM)
-                .setNumberOfRandomlySelectedQuestions(2)
-                .setMultipleChoiceQuestions(List.of(
-                        CreateMultipleChoiceQuestionInput.builder()
-                                .setNumber(1)
-                                .setText("What is the answer to life, the universe and everything?")
-                                .setAnswers(List.of(
-                                        MultipleChoiceAnswerInput.builder()
-                                                .setText("42")
-                                                .setCorrect(true)
-                                                .build(),
-                                        MultipleChoiceAnswerInput.builder()
-                                                .setText("24")
-                                                .setCorrect(false)
-                                                .build()
-                                ))
-                                .build(),
-                        CreateMultipleChoiceQuestionInput.builder()
-                                .setNumber(null) // number should be assigned automatically
-                                .setText("What is love?")
-                                .setAnswers(List.of(
-                                        MultipleChoiceAnswerInput.builder()
-                                                .setText("Baby don't hurt me")
-                                                .setCorrect(true)
-                                                .build(),
-                                        MultipleChoiceAnswerInput.builder()
-                                                .setText("A chemical reaction in the brain")
-                                                .setCorrect(false)
-                                                .build()
-                                ))
-                                .build()
-                ))
-                .build();
-
-        String query = """
-                mutation createQuiz($id: UUID!, $input: CreateQuizInput!) {
-                    createQuiz(assessmentId: $id, input: $input) {
-                        assessmentId
-                        requiredCorrectAnswers
-                        questionPoolingMode
-                        numberOfRandomlySelectedQuestions
-                        questionPool {
-                            number
-                            hint
-                            type
-                            ... on MultipleChoiceQuestion {
-                                text
-                                answers {
-                                    text
-                                    correct
-                                    feedback
-                                }
-                            }
-                        }
-                    }
-                }""";
-
-        // note that deserialization of the result into Quiz dto is not possible because "Question" is an interface
-        // so check the fields manually
-        List<MultipleChoiceQuestion> questions = graphQlTester.document(query)
-                .variable("input", createQuizInput)
-                .variable("id", assessmentId)
-                .execute()
-
-                .path("createQuiz.assessmentId").entity(UUID.class)
-                .isEqualTo(assessmentId)
-
-                .path("createQuiz.requiredCorrectAnswers").entity(Integer.class)
-                .isEqualTo(1)
-
-                .path("createQuiz.questionPoolingMode").entity(QuestionPoolingMode.class)
-                .isEqualTo(QuestionPoolingMode.RANDOM)
-
-                .path("createQuiz.numberOfRandomlySelectedQuestions").entity(Integer.class)
-                .isEqualTo(2)
-
-                .path("createQuiz.questionPool")
-                .entityList(MultipleChoiceQuestion.class)
-                .get();
-
-        assertThat(questions, hasSize(2));
-        assertThat(questions.get(0), matchesInput(createQuizInput.getMultipleChoiceQuestions().get(0)));
-
-        CreateMultipleChoiceQuestionInput expectedQuestion = createQuizInput.getMultipleChoiceQuestions().get(1);
-        expectedQuestion.setNumber(2); // number should be assigned automatically
-        assertThat(questions.get(1), matchesInput(expectedQuestion));
-
-        assertThat(quizRepository.count(), is(1L));
-        assertThat(quizRepository.findAll().get(0), matchesCreateQuizInput(createQuizInput));
-    }
-
-    /**
-     * Given a quiz with two questions with the same number
-     * When the quiz is created
-     * Then a validation error is returned
-     */
-    @Test
-    void testCreateQuizWithDuplicateNumbersInQuestion(GraphQlTester graphQlTester) {
-        UUID assessmentId = UUID.randomUUID();
-        CreateQuizInput createQuizInput = CreateQuizInput.builder()
-                .setRequiredCorrectAnswers(1)
-                .setQuestionPoolingMode(QuestionPoolingMode.RANDOM)
-                .setNumberOfRandomlySelectedQuestions(2)
-                .setMultipleChoiceQuestions(List.of(
-                        CreateMultipleChoiceQuestionInput.builder()
-                                .setNumber(2)
-                                .setText("What is the answer to life, the universe and everything?")
-                                .setAnswers(List.of(
-                                        MultipleChoiceAnswerInput.builder()
-                                                .setText("42")
-                                                .setCorrect(true)
-                                                .build(),
-                                        MultipleChoiceAnswerInput.builder()
-                                                .setText("24")
-                                                .setCorrect(false)
-                                                .build()
-                                ))
-                                .build(),
-                        CreateMultipleChoiceQuestionInput.builder()
-                                .setNumber(2)
-                                .setText("What is love?")
-                                .setAnswers(List.of(
-                                        MultipleChoiceAnswerInput.builder()
-                                                .setText("Baby don't hurt me")
-                                                .setCorrect(true)
-                                                .build(),
-                                        MultipleChoiceAnswerInput.builder()
-                                                .setText("A chemical reaction in the brain")
-                                                .setCorrect(false)
-                                                .build()
-                                ))
-                                .build()
-                ))
-                .build();
-
-        String query = """
-                mutation createQuiz($id: UUID!, $input: CreateQuizInput!) {
-                    createQuiz(assessmentId: $id, input: $input) {
-                        assessmentId
-                    }
-                }""";
-
-        graphQlTester.document(query)
-                .variable("input", createQuizInput)
-                .variable("id", assessmentId)
-                .execute()
-                .errors()
-                .satisfy(errors -> {
-                    assertThat(errors, hasSize(1));
-                    var error = errors.get(0);
-                    assertThat(error.getMessage(), containsString("Question numbers must be unique"));
-                    assertThat(error.getExtensions().get("classification"), is("ValidationError"));
-                });
-
     }
 }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/DeleteQuizMutationTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/DeleteQuizMutationTest.java
@@ -1,11 +1,8 @@
 package de.unistuttgart.iste.gits.quiz_service.api.mutation;
 
-import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
-import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
 import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.generated.dto.QuestionPoolingMode;
-import de.unistuttgart.iste.gits.generated.dto.QuestionType;
-import de.unistuttgart.iste.gits.quiz_service.persistence.dao.*;
+import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
 import graphql.ErrorType;
 import org.junit.jupiter.api.Test;
@@ -15,6 +12,7 @@ import org.springframework.graphql.test.tester.GraphQlTester;
 import java.util.List;
 import java.util.UUID;
 
+import static de.unistuttgart.iste.gits.quiz_service.TestData.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -38,21 +36,20 @@ class DeleteQuizMutationTest {
                 .numberOfRandomlySelectedQuestions(1)
                 .requiredCorrectAnswers(1)
                 .questionPool(List.of(
-                        MultipleChoiceQuestionEntity.builder()
-                                .type(QuestionType.MULTIPLE_CHOICE)
-                                .text(new ResourceMarkdownEmbeddable("What is the answer to life, the universe and everything?"))
-                                .number(1)
-                                .answers(List.of(
-                                        MultipleChoiceAnswerEmbeddable.builder()
-                                                .answerText(new ResourceMarkdownEntity("42"))
-                                                .correct(true)
-                                                .build(),
-                                        MultipleChoiceAnswerEmbeddable.builder()
-                                                .answerText(new ResourceMarkdownEntity("24"))
-                                                .correct(false)
-                                                .build()
-                                ))
-                                .build()
+                        createMultipleChoiceQuestion(1,
+                                "what is the capital of Germany?",
+                                "Berlin", "Paris"
+                        ),
+                        createClozeQuestion(2,
+                                clozeText("This is an example text with a "),
+                                clozeBlank("blank"), clozeText(".")
+                        ),
+                        createAssociationQuestion(3,
+                                association("left1", "right1"),
+                                association("left2", "right2")),
+                        createExactAnswerQuestion(4, "question text", "answer text"),
+                        createNumericQuestion(5, "question text", 42),
+                        createSelfAssessmentQuestion(6, "question text", "answer text")
                 ))
                 .build();
         quizRepository.save(quizEntity);

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/DeleteQuizMutationTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/DeleteQuizMutationTest.java
@@ -1,5 +1,7 @@
 package de.unistuttgart.iste.gits.quiz_service.api.mutation;
 
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
 import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.generated.dto.QuestionPoolingMode;
 import de.unistuttgart.iste.gits.generated.dto.QuestionType;
@@ -38,15 +40,15 @@ class DeleteQuizMutationTest {
                 .questionPool(List.of(
                         MultipleChoiceQuestionEntity.builder()
                                 .type(QuestionType.MULTIPLE_CHOICE)
-                                .text("What is the answer to life, the universe and everything?")
+                                .text(new ResourceMarkdownEmbeddable("What is the answer to life, the universe and everything?"))
                                 .number(1)
                                 .answers(List.of(
                                         MultipleChoiceAnswerEmbeddable.builder()
-                                                .text("42")
+                                                .answerText(new ResourceMarkdownEntity("42"))
                                                 .correct(true)
                                                 .build(),
                                         MultipleChoiceAnswerEmbeddable.builder()
-                                                .text("24")
+                                                .answerText(new ResourceMarkdownEntity("24"))
                                                 .correct(false)
                                                 .build()
                                 ))

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizAddClozeQuestionTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizAddClozeQuestionTest.java
@@ -1,0 +1,318 @@
+package de.unistuttgart.iste.gits.quiz_service.api.mutation;
+
+import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
+import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
+import de.unistuttgart.iste.gits.generated.dto.*;
+import de.unistuttgart.iste.gits.quiz_service.TestData;
+import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
+import de.unistuttgart.iste.gits.quiz_service.persistence.dao.*;
+import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
+import graphql.ErrorType;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.test.annotation.Commit;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@GraphQlApiTest
+@TablesToDelete({"cloze_question_additional_wrong_answers", "cloze_question_cloze_elements", "cloze_question", "quiz_question_pool", "question", "quiz"})
+class MutateQuizAddClozeQuestionTest {
+
+    private static final String ADD_CLOZE_QUESTION_MUTATION = QuizFragments.FRAGMENT_DEFINITION + """
+            mutation($id: UUID!, $input: CreateClozeQuestionInput!) {
+                mutateQuiz(assessmentId: $id) {
+                    addClozeQuestion(input: $input) {
+                        ...QuizAllFields
+                    }
+                }
+            }
+            """;
+
+    @Autowired
+    private QuizRepository quizRepository;
+
+    /**
+     * Given a quiz
+     * When the "addClozeQuestion" mutation is called with a new question
+     * Then the new question is added to the quiz
+     */
+    @Test
+    @Transactional
+    @Commit
+    void testAddClozeQuestion(GraphQlTester graphQlTester) {
+        QuizEntity quizEntity = TestData.exampleQuizBuilder()
+                .questionPool(List.of())
+                .build();
+        quizEntity = quizRepository.save(quizEntity);
+
+        CreateClozeQuestionInput input = CreateClozeQuestionInput.builder()
+                .setHint(new ResourceMarkdownInput("hint"))
+                .setAdditionalWrongAnswers(List.of("wrong1", "wrong2"))
+                .setShowBlanksList(false)
+                .setClozeElements(List.of(
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.TEXT)
+                                .setText(new ResourceMarkdownInput("what is the capital of France?"))
+                                .build(),
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.BLANK)
+                                .setCorrectAnswer("Paris")
+                                .setFeedback(new ResourceMarkdownInput("feedback"))
+                                .build()
+                ))
+                .build();
+
+
+        graphQlTester.document(ADD_CLOZE_QUESTION_MUTATION)
+                .variable("input", input)
+                .variable("id", quizEntity.getAssessmentId())
+                .execute()
+                .path("mutateQuiz.addClozeQuestion.questionPool[0].number")
+                .entity(Integer.class)
+                .isEqualTo(1)
+
+                .path("mutateQuiz.addClozeQuestion.questionPool[0].showBlanksList")
+                .entity(Boolean.class)
+                .isEqualTo(false)
+
+                .path("mutateQuiz.addClozeQuestion.questionPool[0].additionalWrongAnswers")
+                .entityList(String.class)
+                .isEqualTo(List.of("wrong1", "wrong2"))
+
+                .path("mutateQuiz.addClozeQuestion.questionPool[0].clozeElements[0].text")
+                .entity(ResourceMarkdown.class)
+                .isEqualTo(new ResourceMarkdown("what is the capital of France?", List.of()))
+
+                .path("mutateQuiz.addClozeQuestion.questionPool[0].clozeElements[1].correctAnswer")
+                .entity(String.class)
+                .isEqualTo("Paris")
+
+                .path("mutateQuiz.addClozeQuestion.questionPool[0].clozeElements[1].feedback")
+                .entity(ResourceMarkdown.class)
+                .isEqualTo(new ResourceMarkdown("feedback", List.of()));
+
+        QuestionEntity questionEntity = quizRepository.findById(quizEntity.getAssessmentId())
+                .orElseThrow()
+                .getQuestionPool()
+                .get(0);
+
+        assertThat(questionEntity, instanceOf(ClozeQuestionEntity.class));
+        ClozeQuestionEntity clozeQuestionEntity = (ClozeQuestionEntity) questionEntity;
+        assertThat(clozeQuestionEntity.getAdditionalWrongAnswers(), contains("wrong1", "wrong2"));
+        assertThat(clozeQuestionEntity.getClozeElements(), hasSize(2));
+        assertThat(clozeQuestionEntity.getClozeElements().get(0).getType(), is(ClozeElementType.TEXT));
+        assertThat(clozeQuestionEntity.getClozeElements().get(0).getText().getText(), is("what is the capital of France?"));
+        assertThat(clozeQuestionEntity.getClozeElements().get(1).getType(), is(ClozeElementType.BLANK));
+        assertThat(clozeQuestionEntity.getClozeElements().get(1).getCorrectAnswer(), is("Paris"));
+        assertThat(clozeQuestionEntity.getClozeElements().get(1).getFeedback().getText(), is("feedback"));
+
+        assertThat(clozeQuestionEntity.getHint().getText(), is("hint"));
+    }
+
+    /**
+     * Given a quiz
+     * When the "addClozeQuestion" mutation is called with no blank
+     * Then an error is returned
+     */
+    @Test
+    void testAddClozeWithoutBlank(GraphQlTester graphQlTester) {
+        QuizEntity quizEntity = TestData.exampleQuizBuilder()
+                .questionPool(List.of())
+                .build();
+        quizEntity = quizRepository.save(quizEntity);
+
+        CreateClozeQuestionInput input = CreateClozeQuestionInput.builder()
+                .setNumber(1)
+                .setShowBlanksList(true)
+                .setClozeElements(List.of(
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.TEXT)
+                                .setText(new ResourceMarkdownInput("Some text"))
+                                .build(),
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.TEXT)
+                                .setText(new ResourceMarkdownInput("text"))
+                                .build()))
+                .build();
+
+        graphQlTester.document(ADD_CLOZE_QUESTION_MUTATION)
+                .variable("input", input)
+                .variable("id", quizEntity.getAssessmentId())
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertThat(errors, hasSize(1));
+                    assertThat(errors.get(0).getMessage(),
+                            containsString("most contain at least one blank"));
+                    assertThat(errors.get(0).getErrorType(), is(ErrorType.ValidationError));
+                });
+    }
+
+    @Test
+    void addClozeTextElementWithFeedback(GraphQlTester graphQlTester) {
+        QuizEntity quizEntity = TestData.exampleQuizBuilder()
+                .questionPool(List.of())
+                .build();
+        quizEntity = quizRepository.save(quizEntity);
+
+        CreateClozeQuestionInput input = CreateClozeQuestionInput.builder()
+                .setNumber(1)
+                .setShowBlanksList(true)
+                .setClozeElements(List.of(
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.TEXT)
+                                .setText(new ResourceMarkdownInput("Some text"))
+                                .setFeedback(new ResourceMarkdownInput("feedback"))
+                                .build(),
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.BLANK)
+                                .setCorrectAnswer("correct")
+                                .build()))
+                .build();
+
+        graphQlTester.document(ADD_CLOZE_QUESTION_MUTATION)
+                .variable("input", input)
+                .variable("id", quizEntity.getAssessmentId())
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertThat(errors, hasSize(1));
+                    assertThat(errors.get(0).getMessage(),
+                            containsString("text elements cannot have feedback"));
+                    assertThat(errors.get(0).getErrorType(), is(ErrorType.ValidationError));
+                });
+    }
+
+    @Test
+    void addClozeElementWithCorrectAnswer(GraphQlTester graphQlTester) {
+        QuizEntity quizEntity = TestData.exampleQuizBuilder()
+                .questionPool(List.of())
+                .build();
+        quizEntity = quizRepository.save(quizEntity);
+
+        CreateClozeQuestionInput input = CreateClozeQuestionInput.builder()
+                .setNumber(1)
+                .setShowBlanksList(true)
+                .setClozeElements(List.of(
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.TEXT)
+                                .setCorrectAnswer("correct")
+                                .build(),
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.BLANK)
+                                .setCorrectAnswer("correct")
+                                .build()))
+                .build();
+
+        graphQlTester.document(ADD_CLOZE_QUESTION_MUTATION)
+                .variable("input", input)
+                .variable("id", quizEntity.getAssessmentId())
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertThat(errors, hasSize(1));
+                    assertThat(errors.get(0).getMessage(),
+                            containsString("correct answer is not allowed for text elements"));
+                    assertThat(errors.get(0).getErrorType(), is(ErrorType.ValidationError));
+                });
+    }
+
+    @Test
+    void addClozeTextElementWithoutText(GraphQlTester graphQlTester) {
+        QuizEntity quizEntity = TestData.exampleQuizBuilder()
+                .questionPool(List.of())
+                .build();
+        quizEntity = quizRepository.save(quizEntity);
+
+        CreateClozeQuestionInput input = CreateClozeQuestionInput.builder()
+                .setNumber(1)
+                .setShowBlanksList(true)
+                .setClozeElements(List.of(
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.TEXT)
+                                .build(),
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.BLANK)
+                                .setCorrectAnswer("correct")
+                                .build()))
+                .build();
+
+        graphQlTester.document(ADD_CLOZE_QUESTION_MUTATION)
+                .variable("input", input)
+                .variable("id", quizEntity.getAssessmentId())
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertThat(errors, hasSize(1));
+                    assertThat(errors.get(0).getMessage(),
+                            containsString("text is required for cloze text elements"));
+                    assertThat(errors.get(0).getErrorType(), is(ErrorType.ValidationError));
+                });
+    }
+
+    @Test
+    void testAddBlankWithoutCorrectAnswer(GraphQlTester tester) {
+        QuizEntity quizEntity = TestData.exampleQuizBuilder()
+                .questionPool(List.of())
+                .build();
+        quizEntity = quizRepository.save(quizEntity);
+
+        CreateClozeQuestionInput input = CreateClozeQuestionInput.builder()
+                .setNumber(1)
+                .setShowBlanksList(true)
+                .setClozeElements(List.of(
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.BLANK)
+                                .build()))
+                .build();
+
+        tester.document(ADD_CLOZE_QUESTION_MUTATION)
+                .variable("input", input)
+                .variable("id", quizEntity.getAssessmentId())
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertThat(errors, hasSize(1));
+                    assertThat(errors.get(0).getMessage(),
+                            containsString("correct answer is required for cloze blank elements"));
+                    assertThat(errors.get(0).getErrorType(), is(ErrorType.ValidationError));
+                });
+    }
+
+    @Test
+    void testAddBlankWithText(GraphQlTester graphQlTester) {
+        QuizEntity quizEntity = TestData.exampleQuizBuilder()
+                .questionPool(List.of())
+                .build();
+        quizEntity = quizRepository.save(quizEntity);
+
+        CreateClozeQuestionInput input = CreateClozeQuestionInput.builder()
+                .setNumber(1)
+                .setShowBlanksList(true)
+                .setClozeElements(List.of(
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.BLANK)
+                                .setText(new ResourceMarkdownInput("text"))
+                                .setCorrectAnswer("correct")
+                                .build()))
+                .build();
+
+        graphQlTester.document(ADD_CLOZE_QUESTION_MUTATION)
+                .variable("input", input)
+                .variable("id", quizEntity.getAssessmentId())
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertThat(errors, hasSize(1));
+                    assertThat(errors.get(0).getMessage(),
+                            containsString("text is not allowed for cloze blank elements"));
+                    assertThat(errors.get(0).getErrorType(), is(ErrorType.ValidationError));
+                });
+    }
+
+}

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizAddMultipleChoiceQuestionTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizAddMultipleChoiceQuestionTest.java
@@ -4,6 +4,7 @@ import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
 import de.unistuttgart.iste.gits.generated.dto.*;
 import de.unistuttgart.iste.gits.quiz_service.TestData;
+import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
 import graphql.ErrorType;
@@ -23,6 +24,16 @@ import static org.hamcrest.Matchers.*;
 @TablesToDelete({"multiple_choice_question_answers", "multiple_choice_question", "quiz_question_pool", "question", "quiz"})
 class MutateQuizAddMultipleChoiceQuestionTest {
 
+    private static final String UPDATE_MULTIPLE_CHOICE_QUESTION_MUTATION = QuizFragments.FRAGMENT_DEFINITION + """
+            mutation($id: UUID!, $input: CreateMultipleChoiceQuestionInput!) {
+                mutateQuiz(assessmentId: $id) {
+                    addMultipleChoiceQuestion(input: $input) {
+                        ...QuizAllFields
+                    }
+                }
+            }
+            """;
+
     @Autowired
     private QuizRepository quizRepository;
 
@@ -40,42 +51,20 @@ class MutateQuizAddMultipleChoiceQuestionTest {
         quizEntity = quizRepository.save(quizEntity);
 
         CreateMultipleChoiceQuestionInput input = CreateMultipleChoiceQuestionInput.builder()
-                .setText("what is the capital of France?")
+                .setText(new ResourceMarkdownInput("what is the capital of France?"))
                 .setNumber(2)
                 .setAnswers(List.of(
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Paris")
+                                .setAnswerText(new ResourceMarkdownInput("Paris"))
                                 .setCorrect(true)
                                 .build(),
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Madrid")
+                                .setAnswerText(new ResourceMarkdownInput("Madrid"))
                                 .setCorrect(false)
                                 .build()))
                 .build();
 
-        String query = """
-                mutation($id: UUID!, $input: CreateMultipleChoiceQuestionInput!) {
-                    mutateQuiz(assessmentId: $id) {
-                        addMultipleChoiceQuestion(input: $input) {
-                            questionPool {
-                                number
-                                type
-                                hint
-                                ... on MultipleChoiceQuestion {
-                                    text
-                                    answers {
-                                        text
-                                        correct
-                                        feedback
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                """;
-
-        List<MultipleChoiceQuestion> questions = graphQlTester.document(query)
+        List<MultipleChoiceQuestion> questions = graphQlTester.document(UPDATE_MULTIPLE_CHOICE_QUESTION_MUTATION)
                 .variable("input", input)
                 .variable("id", quizEntity.getAssessmentId())
                 .execute()
@@ -102,42 +91,20 @@ class MutateQuizAddMultipleChoiceQuestionTest {
         quizEntity = quizRepository.save(quizEntity);
 
         CreateMultipleChoiceQuestionInput input = CreateMultipleChoiceQuestionInput.builder()
-                .setText("what is the capital of France?")
+                .setText(new ResourceMarkdownInput("what is the capital of France?"))
                 .setNumber(null) // number should be assigned automatically
                 .setAnswers(List.of(
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Paris")
+                                .setAnswerText(new ResourceMarkdownInput("Paris"))
                                 .setCorrect(true)
                                 .build(),
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Madrid")
+                                .setAnswerText(new ResourceMarkdownInput("Madrid"))
                                 .setCorrect(false)
                                 .build()))
                 .build();
 
-        String query = """
-                mutation($id: UUID!, $input: CreateMultipleChoiceQuestionInput!) {
-                    mutateQuiz(assessmentId: $id) {
-                        addMultipleChoiceQuestion(input: $input) {
-                            questionPool {
-                                number
-                                type
-                                hint
-                                ... on MultipleChoiceQuestion {
-                                    text
-                                    answers {
-                                        text
-                                        correct
-                                        feedback
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                """;
-
-        List<MultipleChoiceQuestion> questions = graphQlTester.document(query)
+        List<MultipleChoiceQuestion> questions = graphQlTester.document(UPDATE_MULTIPLE_CHOICE_QUESTION_MUTATION)
                 .variable("input", input)
                 .variable("id", quizEntity.getAssessmentId())
                 .execute()
@@ -166,42 +133,20 @@ class MutateQuizAddMultipleChoiceQuestionTest {
         quizEntity = quizRepository.save(quizEntity);
 
         CreateMultipleChoiceQuestionInput input = CreateMultipleChoiceQuestionInput.builder()
-                .setText("what is the capital of France?")
+                .setText(new ResourceMarkdownInput("what is the capital of France?"))
                 .setNumber(1) // already existing number
                 .setAnswers(List.of(
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Paris")
+                                .setAnswerText(new ResourceMarkdownInput("Paris"))
                                 .setCorrect(true)
                                 .build(),
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Madrid")
+                                .setAnswerText(new ResourceMarkdownInput("Madrid"))
                                 .setCorrect(false)
                                 .build()))
                 .build();
 
-        String query = """
-                mutation($id: UUID!, $input: CreateMultipleChoiceQuestionInput!) {
-                    mutateQuiz(assessmentId: $id) {
-                        addMultipleChoiceQuestion(input: $input) {
-                            questionPool {
-                                number
-                                type
-                                hint
-                                ... on MultipleChoiceQuestion {
-                                    text
-                                    answers {
-                                        text
-                                        correct
-                                        feedback
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                """;
-
-        graphQlTester.document(query)
+        graphQlTester.document(UPDATE_MULTIPLE_CHOICE_QUESTION_MUTATION)
                 .variable("input", input)
                 .variable("id", quizEntity.getAssessmentId())
                 .execute()
@@ -228,41 +173,19 @@ class MutateQuizAddMultipleChoiceQuestionTest {
         quizEntity = quizRepository.save(quizEntity);
 
         CreateMultipleChoiceQuestionInput input = CreateMultipleChoiceQuestionInput.builder()
-                .setText("what is the capital of France?")
+                .setText(new ResourceMarkdownInput("what is the capital of France?"))
                 .setAnswers(List.of(
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Berlin")
+                                .setAnswerText(new ResourceMarkdownInput("Berlin"))
                                 .setCorrect(false)
                                 .build(),
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Madrid")
+                                .setAnswerText(new ResourceMarkdownInput("Madrid"))
                                 .setCorrect(false)
                                 .build()))
                 .build();
 
-        String query = """
-                mutation($id: UUID!, $input: CreateMultipleChoiceQuestionInput!) {
-                    mutateQuiz(assessmentId: $id) {
-                        addMultipleChoiceQuestion(input: $input) {
-                            questionPool {
-                                number
-                                type
-                                hint
-                                ... on MultipleChoiceQuestion {
-                                    text
-                                    answers {
-                                        text
-                                        correct
-                                        feedback
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                """;
-
-        graphQlTester.document(query)
+        graphQlTester.document(UPDATE_MULTIPLE_CHOICE_QUESTION_MUTATION)
                 .variable("input", input)
                 .variable("id", quizEntity.getAssessmentId())
                 .execute()
@@ -289,37 +212,15 @@ class MutateQuizAddMultipleChoiceQuestionTest {
         quizEntity = quizRepository.save(quizEntity);
 
         CreateMultipleChoiceQuestionInput input = CreateMultipleChoiceQuestionInput.builder()
-                .setText("what is the capital of France?")
+                .setText(new ResourceMarkdownInput("what is the capital of France?"))
                 .setAnswers(List.of(
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Paris")
+                                .setAnswerText(new ResourceMarkdownInput("Paris"))
                                 .setCorrect(true)
                                 .build()))
                 .build();
 
-        String query = """
-                mutation($id: UUID!, $input: CreateMultipleChoiceQuestionInput!) {
-                    mutateQuiz(assessmentId: $id) {
-                        addMultipleChoiceQuestion(input: $input) {
-                            questionPool {
-                                number
-                                type
-                                hint
-                                ... on MultipleChoiceQuestion {
-                                    text
-                                    answers {
-                                        text
-                                        correct
-                                        feedback
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                """;
-
-        graphQlTester.document(query)
+        graphQlTester.document(UPDATE_MULTIPLE_CHOICE_QUESTION_MUTATION)
                 .variable("input", input)
                 .variable("id", quizEntity.getAssessmentId())
                 .execute()

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizRemoveQuestionTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizRemoveQuestionTest.java
@@ -4,6 +4,7 @@ import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
 import de.unistuttgart.iste.gits.generated.dto.MultipleChoiceQuestion;
 import de.unistuttgart.iste.gits.quiz_service.TestData;
+import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.MultipleChoiceQuestionEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
@@ -44,27 +45,16 @@ class MutateQuizRemoveQuestionTest {
                 .build();
         quizEntity = quizRepository.save(quizEntity);
 
-        String query = """
+        String query = QuizFragments.FRAGMENT_DEFINITION + """
                 mutation($id: UUID!) {
                     mutateQuiz(assessmentId: $id) {
                         removeQuestion(number: 2) {
-                            questionPool {
-                                number
-                                type
-                                hint
-                                ... on MultipleChoiceQuestion {
-                                    text
-                                    answers {
-                                        text
-                                        correct
-                                        feedback
-                                    }
-                                }
-                            }
+                            ...QuizAllFields
                         }
                     }
                 }
                 """;
+
         List<MultipleChoiceQuestion> questions = graphQlTester.document(query)
                 .variable("id", quizEntity.getAssessmentId())
                 .execute()

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizSwitchQuestionsTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizSwitchQuestionsTest.java
@@ -4,6 +4,7 @@ import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
 import de.unistuttgart.iste.gits.generated.dto.MultipleChoiceQuestion;
 import de.unistuttgart.iste.gits.quiz_service.TestData;
+import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuestionEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
@@ -48,23 +49,11 @@ class MutateQuizSwitchQuestionsTest {
                 .build();
         quizEntity = quizRepository.save(quizEntity);
 
-        String query = """
+        String query = QuizFragments.FRAGMENT_DEFINITION + """
                 mutation($id: UUID!) {
                     mutateQuiz(assessmentId: $id) {
                         switchQuestions(firstNumber: 2, secondNumber: 3) {
-                            questionPool {
-                                number
-                                type
-                                hint
-                                ... on MultipleChoiceQuestion {
-                                    text
-                                    answers {
-                                        text
-                                        correct
-                                        feedback
-                                    }
-                                }
-                            }
+                            ...QuizAllFields
                         }
                     }
                 }
@@ -106,7 +95,7 @@ class MutateQuizSwitchQuestionsTest {
      * Then an error is returned
      */
     @Test
-    void testRemoveQuestionNonExisting(GraphQlTester graphQlTester) {
+    void testSwotchQuestionNonExisting(GraphQlTester graphQlTester) {
         QuizEntity quizEntity = TestData.exampleQuizBuilder()
                 .questionPool(List.of(
                         createMultipleChoiceQuestion(1, "what is the capital of Germany?", "Berlin", "Paris"),

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizUpdateClozeQuestionTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizUpdateClozeQuestionTest.java
@@ -1,0 +1,114 @@
+package de.unistuttgart.iste.gits.quiz_service.api.mutation;
+
+import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
+import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
+import de.unistuttgart.iste.gits.generated.dto.*;
+import de.unistuttgart.iste.gits.quiz_service.TestData;
+import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
+import de.unistuttgart.iste.gits.quiz_service.persistence.dao.ClozeQuestionEntity;
+import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
+import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.test.annotation.Commit;
+
+import java.util.List;
+
+import static de.unistuttgart.iste.gits.quiz_service.TestData.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@GraphQlApiTest
+@TablesToDelete({"cloze_question_additional_wrong_answers", "cloze_question_cloze_elements", "cloze_question", "quiz_question_pool", "question", "quiz"})
+class MutateQuizUpdateClozeQuestionTest {
+
+    @Autowired
+    private QuizRepository quizRepository;
+
+    @Test
+    @Transactional
+    @Commit
+    void testUpdateClozeQuestion(GraphQlTester graphQlTester) {
+        QuizEntity quizEntity = TestData.exampleQuizBuilder()
+                .questionPool(List.of(
+                        createClozeQuestion(1,
+                                clozeText("This is an example text with a "),
+                                clozeBlank("blank"), clozeText("."))))
+                .build();
+        quizEntity = quizRepository.save(quizEntity);
+
+        UpdateClozeQuestionInput input = UpdateClozeQuestionInput.builder()
+                .setId(quizEntity.getQuestionPool().get(0).getId())
+                .setClozeElements(List.of(
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.TEXT)
+                                .setText(new ResourceMarkdownInput("This is an example text with a blank."))
+                                .build(),
+                        ClozeElementInput.builder()
+                                .setType(ClozeElementType.BLANK)
+                                .setCorrectAnswer("blank")
+                                .setFeedback(new ResourceMarkdownInput("new feedback"))
+                                .build()))
+                .setShowBlanksList(false)
+                .setHint(new ResourceMarkdownInput("new hint"))
+                .setAdditionalWrongAnswers(List.of("new wrong answer"))
+                .build();
+
+        String query = QuizFragments.FRAGMENT_DEFINITION + """
+                mutation($id: UUID!, $input: UpdateClozeQuestionInput!) {
+                    mutateQuiz(assessmentId: $id) {
+                        updateClozeQuestion(input: $input) {
+                            ...QuizAllFields
+                        }
+                    }
+                }
+                """;
+
+        graphQlTester.document(query)
+                .variable("id", quizEntity.getAssessmentId())
+                .variable("input", input)
+                .execute()
+                .path("mutateQuiz.updateClozeQuestion.questionPool[0].clozeElements[0]")
+                .entity(ClozeTextElement.class)
+                .isEqualTo(ClozeTextElement.builder()
+                        .setText(new ResourceMarkdown("This is an example text with a blank.", List.of()))
+                        .build())
+
+                .path("mutateQuiz.updateClozeQuestion.questionPool[0].clozeElements[1]")
+                .entity(ClozeBlankElement.class)
+                .isEqualTo(ClozeBlankElement.builder()
+                        .setCorrectAnswer("blank")
+                        .setFeedback(new ResourceMarkdown("new feedback", List.of()))
+                        .build())
+
+                .path("mutateQuiz.updateClozeQuestion.questionPool[0].showBlanksList")
+                .entity(Boolean.class)
+                .isEqualTo(false)
+
+                .path("mutateQuiz.updateClozeQuestion.questionPool[0].hint")
+                .entity(ResourceMarkdown.class)
+                .isEqualTo(new ResourceMarkdown("new hint", List.of()))
+
+                .path("mutateQuiz.updateClozeQuestion.questionPool[0].additionalWrongAnswers")
+                .entityList(String.class)
+                .containsExactly("new wrong answer");
+
+        QuizEntity updatedQuiz = quizRepository.findById(quizEntity.getAssessmentId()).orElseThrow();
+        assertThat(updatedQuiz.getQuestionPool(), hasSize(1));
+        ClozeQuestionEntity updatedQuestion = (ClozeQuestionEntity) updatedQuiz.getQuestionPool().get(0);
+        assertThat(updatedQuestion.getHint().getText(), is("new hint"));
+        assertThat(updatedQuestion.isShowBlanksList(), is(false));
+        assertThat(updatedQuestion.getAdditionalWrongAnswers(), hasSize(1));
+        assertThat(updatedQuestion.getAdditionalWrongAnswers().get(0), is("new wrong answer"));
+        assertThat(updatedQuestion.getClozeElements(), hasSize(2));
+        assertThat(updatedQuestion.getClozeElements().get(0).getType(), is(ClozeElementType.TEXT));
+        assertThat(updatedQuestion.getClozeElements().get(0).getText().getText(), is("This is an example text with a blank."));
+        assertThat(updatedQuestion.getClozeElements().get(1).getType(), is(ClozeElementType.BLANK));
+        assertThat(updatedQuestion.getClozeElements().get(1).getCorrectAnswer(), is("blank"));
+        assertThat(updatedQuestion.getClozeElements().get(1).getFeedback().getText(), is("new feedback"));
+
+    }
+}

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizUpdateMultipleChoiceQuestionTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/mutation/MutateQuizUpdateMultipleChoiceQuestionTest.java
@@ -4,6 +4,7 @@ import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
 import de.unistuttgart.iste.gits.generated.dto.*;
 import de.unistuttgart.iste.gits.quiz_service.TestData;
+import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
 import jakarta.transaction.Transactional;
@@ -39,36 +40,23 @@ class MutateQuizUpdateMultipleChoiceQuestionTest {
 
         UpdateMultipleChoiceQuestionInput input = UpdateMultipleChoiceQuestionInput.builder()
                 .setId(quizEntity.getQuestionPool().get(0).getId())
-                .setText("what is the capital of France?")
+                .setText(new ResourceMarkdownInput("what is the capital of France?"))
                 .setAnswers(List.of(
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Paris")
+                                .setAnswerText(new ResourceMarkdownInput("Paris"))
                                 .setCorrect(true)
                                 .build(),
                         MultipleChoiceAnswerInput.builder()
-                                .setText("Madrid")
+                                .setAnswerText(new ResourceMarkdownInput("Madrid"))
                                 .setCorrect(false)
                                 .build()))
                 .build();
 
-        String query = """
+        String query = QuizFragments.FRAGMENT_DEFINITION + """
                 mutation($id: UUID!, $input: UpdateMultipleChoiceQuestionInput!) {
                     mutateQuiz(assessmentId: $id) {
                         updateMultipleChoiceQuestion(input: $input) {
-                            questionPool {
-                                id
-                                number
-                                type
-                                hint
-                                ... on MultipleChoiceQuestion {
-                                    text
-                                    answers {
-                                        text
-                                        correct
-                                        feedback
-                                    }
-                                }
-                            }
+                            ...QuizAllFields
                         }
                     }
                 }
@@ -83,6 +71,7 @@ class MutateQuizUpdateMultipleChoiceQuestionTest {
                 .get();
 
         assertThat(questions, hasSize(1));
+        System.out.println(questions.get(0));
         assertThat(questions.get(0), matchesInput(input));
 
         QuizEntity updatedQuiz = quizRepository.findById(quizEntity.getAssessmentId()).orElseThrow();

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/query/QueryByIdTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/query/QueryByIdTest.java
@@ -4,6 +4,7 @@ import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
 import de.unistuttgart.iste.gits.generated.dto.MultipleChoiceQuestion;
 import de.unistuttgart.iste.gits.generated.dto.QuestionPoolingMode;
+import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
 import org.junit.jupiter.api.Test;
@@ -92,26 +93,10 @@ class QueryByIdTest {
                 .build();
         quizRepository.save(quizEntity);
 
-        String query = """
+        String query = QuizFragments.FRAGMENT_DEFINITION + """
                 query($id: UUID!) {
                     findQuizzesByAssessmentIds(assessmentIds: [$id]) {
-                        assessmentId
-                        requiredCorrectAnswers
-                        questionPoolingMode
-                        numberOfRandomlySelectedQuestions
-                        questionPool {
-                            number
-                            hint
-                            type
-                            ... on MultipleChoiceQuestion {
-                                text
-                                answers {
-                                    text
-                                    correct
-                                    feedback
-                                }
-                            }
-                        }
+                        ...QuizAllFields
                     }
                 }
                 """;
@@ -159,21 +144,12 @@ class QueryByIdTest {
                 .build();
         quizRepository.save(quizEntity);
 
-        String query = """
+        String query = QuizFragments.FRAGMENT_DEFINITION + """
                 query($id: UUID!) {
                     findQuizzesByAssessmentIds(assessmentIds: [$id]) {
+                        ...QuizAllFields
                         selectedQuestions {
-                            number
-                            hint
-                            type
-                            ... on MultipleChoiceQuestion {
-                                text
-                                answers {
-                                    text
-                                    correct
-                                    feedback
-                                }
-                            }
+                            ...QuestionsAllFields
                         }
                     }
                 }
@@ -193,7 +169,7 @@ class QueryByIdTest {
     }
 
     /**
-     * Given a quiz with three questions and question pooling mode "RANDOM" and numberOfRandomlySelectedQuestions = 2
+     * Given a quiz with three questions and question pooling mode "RANDOM" and numberOfRandomlySelectedQuestions = 1
      * When the "quizByAssessmentId" query is executed
      * Then the selected questions are the equal to the question pool in a random order
      */
@@ -211,21 +187,12 @@ class QueryByIdTest {
                 .build();
         quizRepository.save(quizEntity);
 
-        String query = """
+        String query = QuizFragments.FRAGMENT_DEFINITION + """
                 query($id: UUID!) {
                     findQuizzesByAssessmentIds(assessmentIds: [$id]) {
+                        ...QuizAllFields
                         selectedQuestions {
-                            number
-                            hint
-                            type
-                            ... on MultipleChoiceQuestion {
-                                text
-                                answers {
-                                    text
-                                    correct
-                                    feedback
-                                }
-                            }
+                            ...QuestionsAllFields
                         }
                     }
                 }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/query/QueryByIdTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/api/query/QueryByIdTest.java
@@ -1,9 +1,9 @@
 package de.unistuttgart.iste.gits.quiz_service.api.query;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.unistuttgart.iste.gits.common.testutil.GraphQlApiTest;
 import de.unistuttgart.iste.gits.common.testutil.TablesToDelete;
-import de.unistuttgart.iste.gits.generated.dto.MultipleChoiceQuestion;
-import de.unistuttgart.iste.gits.generated.dto.QuestionPoolingMode;
+import de.unistuttgart.iste.gits.generated.dto.*;
 import de.unistuttgart.iste.gits.quiz_service.api.QuizFragments;
 import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
@@ -14,13 +14,18 @@ import org.springframework.graphql.test.tester.GraphQlTester;
 import java.util.List;
 import java.util.UUID;
 
-import static de.unistuttgart.iste.gits.quiz_service.TestData.createMultipleChoiceQuestion;
+import static de.unistuttgart.iste.gits.quiz_service.TestData.*;
 import static de.unistuttgart.iste.gits.quiz_service.matcher.MultipleChoiceQuestionDtoToEntityMatcher.matchesEntity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @GraphQlApiTest
-@TablesToDelete({"multiple_choice_question_answers", "multiple_choice_question", "quiz_question_pool", "question", "quiz"})
+@TablesToDelete({"multiple_choice_question_answers", "multiple_choice_question",
+        "cloze_question_additional_wrong_answers", "cloze_question_cloze_elements", "cloze_question",
+        "association_question_correct_associations", "association_question",
+        "exact_answer_question_correct_answers", "exact_answer_question",
+        "numeric_question", "self_assessment_question",
+        "quiz_question_pool", "question", "quiz"})
 class QueryByIdTest {
 
     @Autowired
@@ -81,7 +86,7 @@ class QueryByIdTest {
      * Then the correct quiz with the correct data is returned
      */
     @Test
-    void queryQuizWithQuestions(GraphQlTester graphQlTester) {
+    void queryQuizWithQuestions(GraphQlTester graphQlTester) throws Exception {
         QuizEntity quizEntity = QuizEntity.builder()
                 .assessmentId(UUID.randomUUID())
                 .questionPoolingMode(QuestionPoolingMode.RANDOM)
@@ -89,9 +94,96 @@ class QueryByIdTest {
                 .requiredCorrectAnswers(1)
                 .questionPool(List.of(
                         createMultipleChoiceQuestion(1, "What is the answer to life, the universe and everything?",
-                                "42", "24")))
+                                "42", "24"),
+                        createAssociationQuestion(2, association("A", "1"), association("B", "2")),
+                        createClozeQuestion(3, clozeText("text"), clozeBlank("answer")),
+                        createExactAnswerQuestion(4, "question", "answer"),
+                        createNumericQuestion(5, "question", 42),
+                        createSelfAssessmentQuestion(6, "question", "answer")))
                 .build();
-        quizRepository.save(quizEntity);
+        quizEntity = quizRepository.save(quizEntity);
+
+        Question[] expectedQuestions = new Question[]{
+                MultipleChoiceQuestion.builder()
+                        .setNumber(1)
+                        .setText(new ResourceMarkdown("What is the answer to life, the universe and everything?", List.of()))
+                        .setHint(new ResourceMarkdown("hint", List.of()))
+                        .setId(quizEntity.getQuestionPool().get(0).getId())
+                        .setAnswers(List.of(
+                                MultipleChoiceAnswer.builder()
+                                        .setAnswerText(new ResourceMarkdown("42", List.of()))
+                                        .setCorrect(true)
+                                        .setFeedback(new ResourceMarkdown("feedback", List.of()))
+                                        .build(),
+                                MultipleChoiceAnswer.builder()
+                                        .setAnswerText(new ResourceMarkdown("24", List.of()))
+                                        .setCorrect(false)
+                                        .setFeedback(new ResourceMarkdown("feedback", List.of()))
+                                        .build()))
+                        .setType(QuestionType.MULTIPLE_CHOICE)
+                        .setNumberOfCorrectAnswers(1)
+                        .build(),
+                AssociationQuestion.builder()
+                        .setNumber(2)
+                        .setId(quizEntity.getQuestionPool().get(1).getId())
+                        .setText(new ResourceMarkdown("text", List.of()))
+                        .setHint(new ResourceMarkdown("hint", List.of()))
+                        .setId(quizEntity.getQuestionPool().get(1).getId())
+                        .setType(QuestionType.ASSOCIATION)
+                        .setCorrectAssociations(List.of(
+                                new SingleAssociation("A", "1", new ResourceMarkdown("feedback", List.of())),
+                                new SingleAssociation("B", "2", new ResourceMarkdown("feedback", List.of()))))
+                        .setLeftSide(List.of("A", "B"))
+                        .setRightSide(List.of("1", "2"))
+                        .build(),
+                ClozeQuestion.builder()
+                        .setNumber(3)
+                        .setHint(new ResourceMarkdown("hint", List.of()))
+                        .setId(quizEntity.getQuestionPool().get(2).getId())
+                        .setType(QuestionType.CLOZE)
+                        .setShowBlanksList(true)
+                        .setAdditionalWrongAnswers(List.of("wrong1", "wrong2"))
+                        .setClozeElements(List.of(
+                                ClozeTextElement.builder()
+                                        .setText(new ResourceMarkdown("text", List.of()))
+                                        .build(),
+                                ClozeBlankElement.builder()
+                                        .setCorrectAnswer("answer")
+                                        .setFeedback(new ResourceMarkdown("feedback", List.of()))
+                                        .build()))
+                        .setAllBlanks(List.of("answer", "wrong1", "wrong2"))
+                        .build(),
+                ExactAnswerQuestion.builder()
+                        .setNumber(4)
+                        .setHint(new ResourceMarkdown("hint", List.of()))
+                        .setId(quizEntity.getQuestionPool().get(3).getId())
+                        .setType(QuestionType.EXACT_ANSWER)
+                        .setText(new ResourceMarkdown("question", List.of()))
+                        .setCorrectAnswers(List.of("answer"))
+                        .setCaseSensitive(true)
+                        .setFeedback(new ResourceMarkdown("feedback", List.of()))
+                        .build(),
+                NumericQuestion.builder()
+                        .setNumber(5)
+                        .setHint(new ResourceMarkdown("hint", List.of()))
+                        .setId(quizEntity.getQuestionPool().get(4).getId())
+                        .setType(QuestionType.NUMERIC)
+                        .setText(new ResourceMarkdown("question", List.of()))
+                        .setCorrectAnswer(42)
+                        .setFeedback(new ResourceMarkdown("feedback", List.of()))
+                        .setTolerance(1)
+                        .build(),
+                SelfAssessmentQuestion.builder()
+                        .setNumber(6)
+                        .setHint(new ResourceMarkdown("hint", List.of()))
+                        .setId(quizEntity.getQuestionPool().get(5).getId())
+                        .setType(QuestionType.SELF_ASSESSMENT)
+                        .setText(new ResourceMarkdown("question", List.of()))
+                        .setSolutionSuggestion(new ResourceMarkdown("answer", List.of()))
+                        .build()
+        };
+
+        String expectedJson = new ObjectMapper().writeValueAsString(expectedQuestions);
 
         String query = QuizFragments.FRAGMENT_DEFINITION + """
                 query($id: UUID!) {
@@ -101,7 +193,7 @@ class QueryByIdTest {
                 }
                 """;
 
-        List<MultipleChoiceQuestion> questions = graphQlTester.document(query)
+        graphQlTester.document(query)
                 .variable("id", quizEntity.getAssessmentId())
                 .execute()
 
@@ -118,11 +210,8 @@ class QueryByIdTest {
                 .isEqualTo(1)
 
                 .path("findQuizzesByAssessmentIds[0].questionPool")
-                .entityList(MultipleChoiceQuestion.class)
-                .get();
+                .matchesJson(expectedJson);
 
-        assertThat(questions, hasSize(1));
-        assertThat(questions.get(0), matchesEntity(quizEntity.getQuestionPool().get(0)));
     }
 
     /**
@@ -148,9 +237,6 @@ class QueryByIdTest {
                 query($id: UUID!) {
                     findQuizzesByAssessmentIds(assessmentIds: [$id]) {
                         ...QuizAllFields
-                        selectedQuestions {
-                            ...QuestionsAllFields
-                        }
                     }
                 }
                 """;
@@ -191,9 +277,6 @@ class QueryByIdTest {
                 query($id: UUID!) {
                     findQuizzesByAssessmentIds(assessmentIds: [$id]) {
                         ...QuizAllFields
-                        selectedQuestions {
-                            ...QuestionsAllFields
-                        }
                     }
                 }
                 """;

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceAnswerDtoToEntityMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceAnswerDtoToEntityMatcher.java
@@ -5,7 +5,7 @@ import de.unistuttgart.iste.gits.quiz_service.persistence.dao.MultipleChoiceAnsw
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import java.util.Objects;
+import static de.unistuttgart.iste.gits.quiz_service.matcher.ResourceMarkdownMatchers.markdownMatches;
 
 /**
  * Matcher for comparing a {@link MultipleChoiceAnswer} to a {@link MultipleChoiceAnswerEmbeddable}.
@@ -24,15 +24,14 @@ public class MultipleChoiceAnswerDtoToEntityMatcher extends TypeSafeDiagnosingMa
 
     @Override
     protected boolean matchesSafely(MultipleChoiceAnswer item, Description mismatchDescription) {
-        if (!item.getText().equals(expected.getText())) {
-            mismatchDescription.appendText("text was ").appendValue(item.getText());
-            return false;
+        if (!markdownMatches(item.getAnswerText(), expected.getAnswerText())) {
+            mismatchDescription.appendText("answer text was ").appendValue(item.getAnswerText());
         }
         if (item.getCorrect() != expected.isCorrect()) {
             mismatchDescription.appendText("correct was ").appendValue(item.getCorrect());
             return false;
         }
-        if (!Objects.equals(item.getFeedback(), expected.getFeedback())) {
+        if (!markdownMatches(item.getFeedback(), expected.getFeedback())) {
             mismatchDescription.appendText("feedback was ").appendValue(item.getFeedback());
             return false;
         }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceAnswerDtoToInputMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceAnswerDtoToInputMatcher.java
@@ -5,7 +5,7 @@ import de.unistuttgart.iste.gits.generated.dto.MultipleChoiceAnswerInput;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import java.util.Objects;
+import static de.unistuttgart.iste.gits.quiz_service.matcher.ResourceMarkdownMatchers.markdownMatches;
 
 /**
  * Matcher for comparing a {@link MultipleChoiceAnswer} to a {@link MultipleChoiceAnswerInput}.
@@ -24,15 +24,15 @@ public class MultipleChoiceAnswerDtoToInputMatcher extends TypeSafeDiagnosingMat
 
     @Override
     protected boolean matchesSafely(MultipleChoiceAnswer item, Description mismatchDescription) {
-        if (!item.getText().equals(expected.getText())) {
-            mismatchDescription.appendText("text was ").appendValue(item.getText());
+        if (!item.getAnswerText().getText().equals(expected.getAnswerText().getText())) {
+            mismatchDescription.appendText("answer text was ").appendValue(item.getAnswerText());
             return false;
         }
         if (item.getCorrect() != expected.getCorrect()) {
             mismatchDescription.appendText("correct was ").appendValue(item.getCorrect());
             return false;
         }
-        if (!Objects.equals(item.getFeedback(), expected.getFeedback())) {
+        if (!markdownMatches(item.getFeedback(), expected.getFeedback())) {
             mismatchDescription.appendText("feedback was ").appendValue(item.getFeedback());
             return false;
         }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceAnswerEntityToInputMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceAnswerEntityToInputMatcher.java
@@ -5,7 +5,7 @@ import de.unistuttgart.iste.gits.quiz_service.persistence.dao.MultipleChoiceAnsw
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-import java.util.Objects;
+import static de.unistuttgart.iste.gits.quiz_service.matcher.ResourceMarkdownMatchers.markdownMatches;
 
 /**
  * Matcher for comparing a {@link MultipleChoiceAnswerEmbeddable} to a {@link MultipleChoiceAnswerInput}.
@@ -24,15 +24,15 @@ public class MultipleChoiceAnswerEntityToInputMatcher extends TypeSafeDiagnosing
 
     @Override
     protected boolean matchesSafely(MultipleChoiceAnswerEmbeddable item, Description mismatchDescription) {
-        if (!item.getText().equals(expected.getText())) {
-            mismatchDescription.appendText("text was ").appendValue(item.getText());
+        if (!markdownMatches(item.getAnswerText(), expected.getAnswerText())) {
+            mismatchDescription.appendText("answer text was ").appendValue(item.getAnswerText());
             return false;
         }
         if (item.isCorrect() != expected.getCorrect()) {
             mismatchDescription.appendText("correct was ").appendValue(item.isCorrect());
             return false;
         }
-        if (!Objects.equals(item.getFeedback(), expected.getFeedback())) {
+        if (!markdownMatches(item.getFeedback(), expected.getFeedback())) {
             mismatchDescription.appendText("feedback was ").appendValue(item.getFeedback());
             return false;
         }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionDtoToCreateInputMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionDtoToCreateInputMatcher.java
@@ -6,6 +6,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Objects;
 
+import static de.unistuttgart.iste.gits.quiz_service.matcher.ResourceMarkdownMatchers.markdownMatches;
+
 /**
  * Matcher for comparing a {@link MultipleChoiceQuestion} to a {@link CreateMultipleChoiceQuestionInput}.
  */
@@ -31,11 +33,11 @@ public class MultipleChoiceQuestionDtoToCreateInputMatcher extends TypeSafeDiagn
             mismatchDescription.appendText("type was ").appendValue(item.getType());
             return false;
         }
-        if (!Objects.equals(item.getHint(), expected.getHint())) {
+        if (!markdownMatches(item.getHint(), expected.getHint())) {
             mismatchDescription.appendText("hint was ").appendValue(item.getHint());
             return false;
         }
-        if (!Objects.equals(item.getText(), expected.getText())) {
+        if (!markdownMatches(item.getText(), expected.getText())) {
             mismatchDescription.appendText("text was ").appendValue(item.getText());
             return false;
         }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionDtoToEntityMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionDtoToEntityMatcher.java
@@ -9,6 +9,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Objects;
 
+import static de.unistuttgart.iste.gits.quiz_service.matcher.ResourceMarkdownMatchers.markdownMatches;
+
 /**
  * Matcher for comparing a {@link MultipleChoiceQuestionEntity} to a {@link MultipleChoiceQuestionEntity}.
  */
@@ -41,12 +43,12 @@ public class MultipleChoiceQuestionDtoToEntityMatcher extends TypeSafeDiagnosing
             mismatchDescription.appendText("type was ").appendValue(item.getType());
             return false;
         }
-        if (!Objects.equals(item.getHint(), multipleChoiceQuestionEntity.getHint())) {
-            mismatchDescription.appendText("hint was ").appendValue(item.getHint());
+        if (!markdownMatches(item.getHint(), expected.getHint())) {
+            mismatchDescription.appendText("hint was ").appendValue(item.getHint().getText());
             return false;
         }
-        if (!Objects.equals(item.getText(), multipleChoiceQuestionEntity.getText())) {
-            mismatchDescription.appendText("text was ").appendValue(item.getText());
+        if (!markdownMatches(item.getText(), multipleChoiceQuestionEntity.getText())) {
+            mismatchDescription.appendText("text was ").appendValue(item.getText().getText());
             return false;
         }
         if (item.getAnswers().size() != multipleChoiceQuestionEntity.getAnswers().size()) {

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionDtoToUpdateInputMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionDtoToUpdateInputMatcher.java
@@ -6,6 +6,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Objects;
 
+import static de.unistuttgart.iste.gits.quiz_service.matcher.ResourceMarkdownMatchers.markdownMatches;
+
 /**
  * Matcher for comparing a {@link MultipleChoiceQuestion} to a {@link UpdateMultipleChoiceQuestionInput}.
  */
@@ -31,12 +33,12 @@ public class MultipleChoiceQuestionDtoToUpdateInputMatcher extends TypeSafeDiagn
             mismatchDescription.appendText("type was ").appendValue(item.getType());
             return false;
         }
-        if (!Objects.equals(item.getHint(), expected.getHint())) {
-            mismatchDescription.appendText("hint was ").appendValue(item.getHint());
+        if (!markdownMatches(item.getHint(), expected.getHint())) {
+            mismatchDescription.appendText("hint was ").appendValue(item.getHint().getText());
             return false;
         }
-        if (!Objects.equals(item.getText(), expected.getText())) {
-            mismatchDescription.appendText("text was ").appendValue(item.getText());
+        if (!markdownMatches(item.getText(), expected.getText())) {
+            mismatchDescription.appendText("text was ").appendValue(item.getText().getText());
             return false;
         }
         if (item.getAnswers().size() != expected.getAnswers().size()) {

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionEntityToCreateInputMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionEntityToCreateInputMatcher.java
@@ -9,6 +9,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Objects;
 
+import static de.unistuttgart.iste.gits.quiz_service.matcher.ResourceMarkdownMatchers.markdownMatches;
+
 /**
  * Matcher for comparing a {@link MultipleChoiceQuestionEntity} to a {@link CreateMultipleChoiceQuestionInput}.
  */
@@ -39,11 +41,11 @@ public class MultipleChoiceQuestionEntityToCreateInputMatcher extends TypeSafeDi
             mismatchDescription.appendText("type was ").appendValue(item.getType());
             return false;
         }
-        if (!Objects.equals(multipleChoiceQuestionEntity.getHint(), expected.getHint())) {
+        if (!markdownMatches(item.getHint(), expected.getHint())) {
             mismatchDescription.appendText("hint was ").appendValue(multipleChoiceQuestionEntity.getHint());
             return false;
         }
-        if (!Objects.equals(multipleChoiceQuestionEntity.getText(), expected.getText())) {
+        if (!markdownMatches(multipleChoiceQuestionEntity.getText(), expected.getText())) {
             mismatchDescription.appendText("text was ").appendValue(multipleChoiceQuestionEntity.getText());
             return false;
         }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionEntityToUpdateInputMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/MultipleChoiceQuestionEntityToUpdateInputMatcher.java
@@ -9,6 +9,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Objects;
 
+import static de.unistuttgart.iste.gits.quiz_service.matcher.ResourceMarkdownMatchers.markdownMatches;
+
 /**
  * Matcher for comparing a {@link QuestionEntity} to a {@link UpdateMultipleChoiceQuestionInput}.
  */
@@ -34,7 +36,7 @@ public class MultipleChoiceQuestionEntityToUpdateInputMatcher extends TypeSafeDi
             mismatchDescription.appendText("type was ").appendValue(item.getType());
             return false;
         }
-        if (!Objects.equals(item.getHint(), expected.getHint())) {
+        if (!markdownMatches(item.getHint(), expected.getHint())) {
             mismatchDescription.appendText("hint was ").appendValue(item.getHint());
             return false;
         }
@@ -44,7 +46,7 @@ public class MultipleChoiceQuestionEntityToUpdateInputMatcher extends TypeSafeDi
             return false;
         }
 
-        if (!Objects.equals(multipleChoiceQuestionEntity.getText(), expected.getText())) {
+        if (!markdownMatches(multipleChoiceQuestionEntity.getText(), expected.getText())) {
             mismatchDescription.appendText("text was ").appendValue(multipleChoiceQuestionEntity.getText());
             return false;
         }

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/QuizEntityToCreateInputMatcher.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/QuizEntityToCreateInputMatcher.java
@@ -7,8 +7,6 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Objects;
 
-import static de.unistuttgart.iste.gits.quiz_service.matcher.MultipleChoiceQuestionEntityToCreateInputMatcher.matchesInput;
-
 /**
  * Matcher for comparing a {@link QuizEntity} to a {@link CreateQuizInput}.
  */
@@ -37,18 +35,6 @@ public class QuizEntityToCreateInputMatcher extends TypeSafeDiagnosingMatcher<Qu
         if (!Objects.equals(item.getNumberOfRandomlySelectedQuestions(), expected.getNumberOfRandomlySelectedQuestions())) {
             mismatchDescription.appendText("numberOfRandomlySelectedQuestions was ").appendValue(item.getNumberOfRandomlySelectedQuestions());
             return false;
-        }
-        if (item.getQuestionPool().size() != expected.getMultipleChoiceQuestions().size()) {
-            // TODO add other question types
-            mismatchDescription.appendText("questionPool size was ").appendValue(item.getQuestionPool().size());
-            return false;
-        }
-
-        for (int i = 0; i < item.getQuestionPool().size(); i++) {
-            if (!matchesInput(expected.getMultipleChoiceQuestions().get(i))
-                    .matchesSafely(item.getQuestionPool().get(i), mismatchDescription)) {
-                return false;
-            }
         }
 
         return true;

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/ResourceMarkdownMatchers.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/matcher/ResourceMarkdownMatchers.java
@@ -1,0 +1,54 @@
+package de.unistuttgart.iste.gits.quiz_service.matcher;
+
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
+import de.unistuttgart.iste.gits.generated.dto.ResourceMarkdown;
+import de.unistuttgart.iste.gits.generated.dto.ResourceMarkdownInput;
+
+import java.util.Objects;
+
+public class ResourceMarkdownMatchers {
+
+    public static boolean markdownMatches(ResourceMarkdownInput input, ResourceMarkdownEntity entity) {
+        return Objects.equals(
+                input == null ? null : input.getText(),
+                entity == null ? null : entity.getText()
+        );
+    }
+
+    public static boolean markdownMatches(ResourceMarkdownEntity entity, ResourceMarkdownInput input) {
+        return markdownMatches(input, entity);
+    }
+
+    public static boolean markdownMatches(ResourceMarkdown input, ResourceMarkdownEntity entity) {
+        return Objects.equals(
+                input == null ? null : input.getText(),
+                entity == null ? null : entity.getText()
+        );
+    }
+
+    public static boolean markdownMatches(ResourceMarkdownInput input, ResourceMarkdownEmbeddable embeddable) {
+        return Objects.equals(
+                input == null ? null : input.getText(),
+                embeddable == null ? null : embeddable.getText()
+        );
+    }
+
+    public static boolean markdownMatches(ResourceMarkdownEmbeddable embeddable, ResourceMarkdownInput input) {
+        return markdownMatches(input, embeddable);
+    }
+
+    public static boolean markdownMatches(ResourceMarkdown input, ResourceMarkdownEmbeddable embeddable) {
+        return Objects.equals(
+                input == null ? null : input.getText(),
+                embeddable == null ? null : embeddable.getText()
+        );
+    }
+
+    public static boolean markdownMatches(ResourceMarkdown markdown, ResourceMarkdownInput input) {
+        return Objects.equals(
+                markdown == null ? null : markdown.getText(),
+                input == null ? null : input.getText()
+        );
+    }
+}

--- a/src/test/java/de/unistuttgart/iste/gits/quiz_service/service/QuizServiceTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/quiz_service/service/QuizServiceTest.java
@@ -1,14 +1,11 @@
 package de.unistuttgart.iste.gits.quiz_service.service;
 
-import de.unistuttgart.iste.gits.common.event.ContentChangeEvent;
-import de.unistuttgart.iste.gits.common.event.CrudOperation;
-import de.unistuttgart.iste.gits.common.event.UserProgressLogEvent;
+import de.unistuttgart.iste.gits.common.event.*;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEmbeddable;
+import de.unistuttgart.iste.gits.common.resource_markdown.ResourceMarkdownEntity;
 import de.unistuttgart.iste.gits.generated.dto.*;
 import de.unistuttgart.iste.gits.quiz_service.dapr.TopicPublisher;
-import de.unistuttgart.iste.gits.quiz_service.persistence.dao.MultipleChoiceAnswerEmbeddable;
-import de.unistuttgart.iste.gits.quiz_service.persistence.dao.MultipleChoiceQuestionEntity;
-import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuestionEntity;
-import de.unistuttgart.iste.gits.quiz_service.persistence.dao.QuizEntity;
+import de.unistuttgart.iste.gits.quiz_service.persistence.dao.*;
 import de.unistuttgart.iste.gits.quiz_service.persistence.mapper.QuizMapper;
 import de.unistuttgart.iste.gits.quiz_service.persistence.repository.QuizRepository;
 import de.unistuttgart.iste.gits.quiz_service.validation.QuizValidator;
@@ -16,9 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static org.mockito.Mockito.*;
 
@@ -241,30 +236,30 @@ class QuizServiceTest {
     private List<QuestionEntity> createDummyQuestions() {
         List<QuestionEntity> questions = new ArrayList<>();
         MultipleChoiceAnswerEmbeddable wrongAnswer = MultipleChoiceAnswerEmbeddable.builder()
-                .text("Pick me! Pick Me!")
+                .answerText(new ResourceMarkdownEntity("Pick me! Pick Me!"))
                 .correct(false)
-                .feedback("Fell for it")
+                .feedback(new ResourceMarkdownEntity("Fell for it"))
                 .build();
         MultipleChoiceAnswerEmbeddable correctAnswer = MultipleChoiceAnswerEmbeddable.builder()
-                .text("No me!")
+                .answerText(new ResourceMarkdownEntity("No me!"))
                 .correct(true)
-                .feedback("Well done!")
+                .feedback(new ResourceMarkdownEntity("Well done!"))
                 .build();
         MultipleChoiceQuestionEntity questionEntity = MultipleChoiceQuestionEntity.builder()
                 .id(UUID.randomUUID())
                 .number(0)
                 .type(QuestionType.MULTIPLE_CHOICE)
-                .text("This is a question")
+                .text(new ResourceMarkdownEmbeddable("This is a question"))
                 .answers(List.of(wrongAnswer, correctAnswer))
-                .hint("Wink Wink")
+                .hint(new ResourceMarkdownEntity("Wink Wink"))
                 .build();
         MultipleChoiceQuestionEntity questionEntity2 = MultipleChoiceQuestionEntity.builder()
                 .id(UUID.randomUUID())
                 .number(0)
                 .type(QuestionType.MULTIPLE_CHOICE)
-                .text("This is a question")
+                .text(new ResourceMarkdownEmbeddable("This is a question"))
                 .answers(List.of(wrongAnswer, correctAnswer))
-                .hint("Wink Wink")
+                .hint(new ResourceMarkdownEntity("Wink Wink"))
                 .build();
 
         questions.add(questionEntity);


### PR DESCRIPTION
## Description of changes
This pull request will add the following things
- complete schema for all the quiz types (already reviewed, although I made some small changes in development)
- adapt multiple choice questions to resource markdown
- make data base entities for all quiz types
- implement mapping and querying all quiz types
- implement adding cloze questions and updating them

Adding other questions types is not implemented yet, but as the frontend needs to implement clozes, we should merge this sooner.

## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [x] automated unit test
- [x] automated integration test
- [ ] manual, exploratory test
    
## Checklist before requesting a review

- [x] My code is easy to understand
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] My code fulfills all acceptance criteria
- [x] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [x] I made no breaking changes in the database schema or if so, I will perform a database migration

I will probably just delete all quizzes and their questions.

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
