### PR TITLE
correct schema to align with usage of Association quiz association left/right with SlateJS JSON text instead of raw string

### DIFF
--- a/src/main/resources/graphql/service/quiz.graphqls
+++ b/src/main/resources/graphql/service/quiz.graphqls
@@ -245,13 +245,13 @@ type AssociationQuestion implements Question {
 
 type SingleAssociation {
     """
-    The left side of the association.
+    The left side of the association, in SlateJS JSON format.
     """
-    left: String!
+    left: JSON!
     """
-    The right side of the association.
+    The right side of the association, in SlateJS JSON format.
     """
-    right: String!
+    right: JSON!
 
     """
     Feedback for the association when the user assigns a wrong answer, in SlateJS JSON format.


### PR DESCRIPTION
## Description of changes
In the schema the left/right fields were declared as string, but they contain slatejs json strings by the frontend. Change the schema type to reflect the change. Does not have any logic repercussions in the backend.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [ ] manual, exploratory test

Tests unnecessary, just a change of schema to make intent clear.
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
